### PR TITLE
Clean up after PR#6

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMHead.java
+++ b/src/main/java/jenkins/scm/api/SCMHead.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 import jenkins.scm.api.actions.ChangeRequestAction;
 import org.kohsuke.stapler.export.Exported;
@@ -143,15 +142,12 @@ public class SCMHead implements Comparable<SCMHead>, Serializable {
     @Exported(name="actions")
     public List<? extends Action> getAllActions() {
         List<Action> actions = new ArrayList<Action>();
-        Jenkins j = Jenkins.getInstance(); // TODO 1.572+ ExtensionList.lookup
-        if (j != null) {
-            for (TransientActionFactory<?> taf : j.getExtensionList(TransientActionFactory.class)) {
-                if (taf.type().isInstance(this)) {
-                    try {
-                        actions.addAll(createFor(taf));
-                    } catch (Exception e) {
-                        LOGGER.log(Level.SEVERE, "Could not load actions from " + taf + " for " + this, e);
-                    }
+        for (TransientActionFactory<?> taf : ExtensionList.lookup(TransientActionFactory.class)) {
+            if (taf.type().isInstance(this)) {
+                try {
+                    actions.addAll(createFor(taf));
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, "Could not load actions from " + taf + " for " + this, e);
                 }
             }
         }

--- a/src/main/java/jenkins/scm/api/SCMSourceDescriptor.java
+++ b/src/main/java/jenkins/scm/api/SCMSourceDescriptor.java
@@ -25,8 +25,8 @@ package jenkins.scm.api;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.model.Descriptor;
-import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -128,16 +128,10 @@ public abstract class SCMSourceDescriptor extends Descriptor<SCMSource> {
     public static List<SCMSourceDescriptor> forOwner(Class<? extends SCMSourceOwner> clazz,
                                                      boolean onlyUserInstantiable) {
         List<SCMSourceDescriptor> result = new ArrayList<SCMSourceDescriptor>();
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            return result;
-        }
-        for (Descriptor<SCMSource> d : j.getDescriptorList(SCMSource.class)) { // TODO 1.572+ ExtensionList.lookup
-            if (d instanceof SCMSourceDescriptor) {
-                SCMSourceDescriptor descriptor = (SCMSourceDescriptor) d;
-                if (descriptor.isApplicable(clazz) && (!onlyUserInstantiable || descriptor.isUserInstantiable())) {
-                    result.add(descriptor);
-                }
+        for (SCMSourceDescriptor d : ExtensionList.lookup(SCMSourceDescriptor.class)) {
+            SCMSourceDescriptor descriptor = (SCMSourceDescriptor) d;
+            if (descriptor.isApplicable(clazz) && (!onlyUserInstantiable || descriptor.isUserInstantiable())) {
+                result.add(descriptor);
             }
         }
         return result;

--- a/src/main/java/jenkins/scm/api/SCMSourceOwners.java
+++ b/src/main/java/jenkins/scm/api/SCMSourceOwners.java
@@ -23,7 +23,6 @@
  */
 package jenkins.scm.api;
 
-import com.google.common.collect.Iterators;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -31,7 +30,6 @@ import hudson.ExtensionPoint;
 import jenkins.model.Jenkins;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -69,10 +67,7 @@ public abstract class SCMSourceOwners implements ExtensionPoint, Iterable<SCMSou
          * {@inheritDoc}
          */
         public Iterator<SCMSourceOwner> iterator() {
-            Jenkins j = Jenkins.getInstance(); // TODO 1.590+ getActiveInstance
-            if (j == null) {
-                return Iterators.emptyIterator();
-            }
+            Jenkins j = Jenkins.getActiveInstance();
             return j.getAllItems(SCMSourceOwner.class).iterator();
         }
     }


### PR DESCRIPTION
Follow up to https://github.com/jenkinsci/scm-api-plugin/pull/6

That PR upgrades the baseline but did not address `TODO` comments pending on such upgrade.

This PR fixes this. Some small additional cleanups (substitute deprecated findbugs annotations) are also included in the modified files.

Thanks @stephenc and @jglick for comments on the previous PR.

@reviewbybees 