### PR TITLE
API for retrieving a fixed revision

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMRevision.java
+++ b/src/main/java/jenkins/scm/api/SCMRevision.java
@@ -63,6 +63,15 @@ public abstract class SCMRevision implements Serializable {
     public abstract int hashCode();  // force implementers to implement.
 
     /**
+     * Should provide a concise, human-readable summary of this revision in an implementation-dependent format.
+     * <p>{@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    /**
      * Returns {@code true} if and only if this revision is deterministic, in other words that repeated checkouts of
      * this revision will result in the exact same files being checked out. Most modern SCM systems have a deterministic
      * revision, however some of the older ones do not have a deterministic revision for all types of head.

--- a/src/main/java/jenkins/scm/api/SCMSource.java
+++ b/src/main/java/jenkins/scm/api/SCMSource.java
@@ -34,6 +34,7 @@ import net.jcip.annotations.GuardedBy;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -305,6 +306,42 @@ public abstract class SCMSource extends AbstractDescribableImpl<SCMSource>
             }
         }, listener);
         return result.get();
+    }
+
+    /**
+     * Looks up suggested revisions that could be passed to {@link #fetch(String, TaskListener)}.
+     * There is no guarantee that all returned revisions are in fact valid, nor that all valid revisions are returned.
+     * Delegates to {@link #retrieveRevisions}.
+     * @param listener the task listener
+     * @return a possibly empty set of revision names suggested by the implementation
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread has interrupted the current thread.
+     * @since FIXME
+     */
+    @NonNull
+    public final Set<String> fetchRevisions(@CheckForNull TaskListener listener)
+            throws IOException, InterruptedException {
+        return retrieveRevisions(defaultListener(listener));
+    }
+
+    /**
+     * Looks up suggested revisions that could be passed to {@link #fetch(String, TaskListener)}.
+     * There is no guarantee that all returned revisions are in fact valid, nor that all valid revisions are returned.
+     * By default, calls {@link #retrieve(TaskListener)}, thus typically returning only branch names.
+     * @param listener the task listener
+     * @return a possibly empty set of revision names suggested by the implementation
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread has interrupted the current thread.
+     * @since FIXME
+     */
+    @NonNull
+    protected Set<String> retrieveRevisions(@NonNull TaskListener listener)
+            throws IOException, InterruptedException {
+        Set<String> revisions = new HashSet<String>();
+        for (SCMHead head : retrieve(listener)) {
+            revisions.add(head.getName());
+        }
+        return revisions;
     }
 
     /**

--- a/src/main/java/jenkins/scm/api/SCMSource.java
+++ b/src/main/java/jenkins/scm/api/SCMSource.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -258,6 +259,52 @@ public abstract class SCMSource extends AbstractDescribableImpl<SCMSource>
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         return fetch(SCMHeadObserver.select(head), listener).result();
+    }
+
+    /**
+     * Looks up a specific revision based on some SCM-specific set of permissible syntaxes.
+     * Delegates to {@link #retrieve(String, TaskListener)}.
+     * @param revision might be a branch name, a tag name, a cryptographic hash, a revision number, etc.
+     * @param listener the task listener (optional)
+     * @return a valid revision object corresponding to the argument, with a usable corresponding head, or null if malformed or not found
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread has interrupted the current thread.
+     * @since FIXME
+     */
+    @CheckForNull
+    public final SCMRevision fetch(@NonNull String revision, @CheckForNull TaskListener listener)
+            throws IOException, InterruptedException {
+        return retrieve(revision, defaultListener(listener));
+    }
+
+    /**
+     * Looks up a specific revision based on some SCM-specific set of permissible syntaxes.
+     * The default implementation uses {@link #retrieve(SCMHeadObserver, TaskListener)}
+     * and looks for {@link SCMHead#getName} matching the argument (so typically only supporting branch names).
+     * @param revision might be a branch name, a tag name, a cryptographic hash, a revision number, etc.
+     * @param listener the task listener
+     * @return a valid revision object corresponding to the argument, with a usable corresponding head, or null if malformed or not found
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread has interrupted the current thread.
+     * @since FIXME
+     */
+    @CheckForNull
+    protected SCMRevision retrieve(@NonNull final String revision, @NonNull TaskListener listener)
+            throws IOException, InterruptedException {
+        final AtomicReference<SCMRevision> result = new AtomicReference<SCMRevision>();
+        retrieve(new SCMHeadObserver() {
+            @Override
+            public void observe(SCMHead head, SCMRevision rev) {
+                if (head.getName().equals(revision)) {
+                    result.set(rev);
+                }
+            }
+            @Override
+            public boolean isObserving() {
+                return result.get() == null;
+            }
+        }, listener);
+        return result.get();
     }
 
     /**

--- a/src/main/java/jenkins/scm/impl/SingleSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/SingleSCMSource.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.scm.NullSCM;
@@ -94,13 +93,6 @@ public class SingleSCMSource extends SCMSource {
         return scm;
     }
 
-    private synchronized void makeHead() {
-        if (head == null) {
-            head = new SCMHead(name);
-            revisionHash = new SCMRevisionImpl(head);
-        }
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -109,22 +101,11 @@ public class SingleSCMSource extends SCMSource {
     protected synchronized void retrieve(@NonNull SCMHeadObserver observer,
                                          @NonNull TaskListener listener)
             throws IOException {
-        makeHead();
+        if (head == null) {
+            head = new SCMHead(name);
+            revisionHash = new SCMRevisionImpl(head);
+        }
         observer.observe(head, revisionHash);
-    }
-
-    /**
-     * Unconditionally returns the single nondeterministic revision.
-     * The {@code revision} argument is ignored.
-     * For the result of {@link #build(SCMHead, SCMRevision)} to be useful,
-     * ensure that {@link #scm} includes some parameterized fields,
-     * and that {@link Run#getEnvironment(TaskListener)} defines corresponding variables.
-     */
-    @NonNull
-    @Override
-    protected SCMRevision retrieve(String revision, TaskListener listener) throws IOException, InterruptedException {
-        makeHead();
-        return revisionHash;
     }
 
     /**


### PR DESCRIPTION
To be used from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/10. https://github.com/jenkinsci/git-plugin/pull/433 is the reference implementation.

Incorporates #11.

Note that current implementations of `SCMSource` only allow you to access the actual repository contents via the legacy `SCM` API, so use of the `build` method is key. In the future `SCMFileSystem` could be implemented (JENKINS-33273) which would allow you to directly observe files in a given revision without going through `SCM` at all, which would offer some advantages such as the ability to bypass `Run`s.

@reviewbybees