### PR TITLE
Extension point for exposing default branches

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMDefaultBranch.java
+++ b/src/main/java/jenkins/scm/api/SCMDefaultBranch.java
@@ -1,0 +1,18 @@
+package jenkins.scm.api;
+
+import hudson.ExtensionPoint;
+
+/**
+ * Allow implementers to nominate a default "branch"
+ *
+ * Both github and bitbucket have the concept of a master/default branch for a repo.
+ * Generally in git this is by convention (at the time of writing).
+ *
+ *
+ * @author Michael Neale
+ */
+public abstract class SCMDefaultBranch implements ExtensionPoint {
+
+    public abstract String getDefaultBranch(SCMSource scm);
+
+}


### PR DESCRIPTION
Ticket: [JENKINS-38718](https://issues.jenkins-ci.org/browse/JENKINS-38718)

I believe this probably belongs in scm-api, as it is the common denominator that various systems share (github will have to implement this, but not git, as I don't think git has the concept of a default branch, but github does, for example). 

Just opening for discussion...
