### PR TITLE
[JENKINS-41121] Provide an API for SCMHead migration

### DIFF
--- a/docs/consumer.adoc
+++ b/docs/consumer.adoc
@@ -171,6 +171,8 @@ The owner is responsible for:
 
 While it is possible to use a detached `SCMSource` without an owner, when operated in such a fashion, it is exceedingly likely that any required credentials will be unresolved and thus the usage may fail.
 
+When loading `SCMHead` or `SCMRevision` instances from persistence on disk, a consumer is recommended to pass the objects through `SCMHeadMigration.readResolveSCMHead(SCMSource,SCMHead)` or `SCMHeadMigration.readResolveSCMRevision(SCMSource,SCMRevision)`.
+
 ==== `SCMSourceOwner` contract
 
 If you implement `jenkins.scm.api.SCMSourceOwner` your implementation *must*:

--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -754,6 +754,12 @@ The `jenkins.scm.api.SCMSource` implementation will also need a Stapler view for
 
 You will need to have implemented your own `SCMHead` and `SCMRevision` subclasses.
 
+[NOTE]
+.So you didn't implement your own `SCMHead` and `SCMRevision` subclasses and now you want to
+====
+You can register a `SCMHeadMigration` extension to perform any required fix-up.
+====
+
 * For regular branch like things, you will want to extend from `SCMHead` directly.
 +
 [source,java]

--- a/src/main/java/jenkins/scm/api/SCMHeadMigration.java
+++ b/src/main/java/jenkins/scm/api/SCMHeadMigration.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package jenkins.scm.api;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -7,7 +30,7 @@ import hudson.ExtensionPoint;
 
 /**
  * If a {@link SCMSource} plugin needs to migrate the implementation classes for {@link SCMHead} this extension
- * point allows the plugin to register type migrations. For speed of migration implementations should just jump direct
+ * point allows the plugin to register type migrations. For speed of migration implementations should just jump directly
  * to the final end-point and not expect recursive chain walking.
  *
  * @since 2.0.2
@@ -28,9 +51,9 @@ public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R
 
     /**
      * Constructor.
-     *  @param sourceClass The {@link SCMSource} that the migration applies to.
-     * @param headClass   The {@link SCMHead} that the migration applies to.
-     * @param revisionClass
+     * @param sourceClass the {@link SCMSource} that the migration applies to.
+     * @param headClass the {@link SCMHead} that the migration applies to.
+     * @param revisionClass the {@link SCMRevision} that the migration applies to.
      */
     protected SCMHeadMigration(Class<S> sourceClass, Class<H> headClass, Class<R> revisionClass) {
         this.sourceClass = sourceClass;
@@ -39,9 +62,9 @@ public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R
     }
 
     /**
-     * Gets the {@link SCMHead} that the migration applies to.
+     * Gets the {@link SCMSource} that the migration applies to.
      *
-     * @return the {@link SCMHead} that the migration applies to.
+     * @return the {@link SCMSource} that the migration applies to.
      */
     public final Class<S> getSCMSourceClass() {
         return sourceClass;
@@ -57,7 +80,21 @@ public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R
     }
 
     /**
+     * Gets the {@link SCMRevision} that the migration applies to.
+     *
+     * @return the {@link SCMRevision} that the migration applies to.
+     */
+    public final Class<R> getSCMRevisionClass() {
+        return revisionClass;
+    }
+
+    /**
      * Perform a migration.
+     * <p>
+     * <strong>Note:</strong> if you migrate a {@link SCMHead} then most likely you will also want to migrate the
+     * {@link SCMRevision} instances associated with that {@link SCMHead} - at the very least to update
+     * {@link SCMRevision#getHead()}.
+     *
      * @param source the source instance.
      * @param head the candidate head.
      * @return the migrated head or {@code null} if the migration was not appropriate.
@@ -80,7 +117,7 @@ public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R
      * Perform a migration.
      *
      * @param source the source instance.
-     * @param head   the candidate head.
+     * @param head the candidate head.
      * @return the migrated head or the original head.
      */
     @SuppressWarnings("unchecked")
@@ -101,7 +138,7 @@ public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R
      * Perform a migration.
      *
      * @param source the source instance.
-     * @param revision   the candidate revision.
+     * @param revision the candidate revision.
      * @return the migrated revision or the original revision.
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/jenkins/scm/api/SCMHeadMigration.java
+++ b/src/main/java/jenkins/scm/api/SCMHeadMigration.java
@@ -1,0 +1,126 @@
+package jenkins.scm.api;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+/**
+ * If a {@link SCMSource} plugin needs to migrate the implementation classes for {@link SCMHead} this extension
+ * point allows the plugin to register type migrations. For speed of migration implementations should just jump direct
+ * to the final end-point and not expect recursive chain walking.
+ *
+ * @since 2.0.2
+ */
+public abstract class SCMHeadMigration<S extends SCMSource, H extends SCMHead, R extends SCMRevision> implements ExtensionPoint {
+    /**
+     * The {@link SCMSource} that the migration applies to.
+     */
+    private final Class<S> sourceClass;
+    /**
+     * The {@link SCMHead} that the migration applies to.
+     */
+    private final Class<H> headClass;
+    /**
+     * The {@link SCMRevision} that the migration applies to.
+     */
+    private final Class<R> revisionClass;
+
+    /**
+     * Constructor.
+     *  @param sourceClass The {@link SCMSource} that the migration applies to.
+     * @param headClass   The {@link SCMHead} that the migration applies to.
+     * @param revisionClass
+     */
+    protected SCMHeadMigration(Class<S> sourceClass, Class<H> headClass, Class<R> revisionClass) {
+        this.sourceClass = sourceClass;
+        this.headClass = headClass;
+        this.revisionClass = revisionClass;
+    }
+
+    /**
+     * Gets the {@link SCMHead} that the migration applies to.
+     *
+     * @return the {@link SCMHead} that the migration applies to.
+     */
+    public final Class<S> getSCMSourceClass() {
+        return sourceClass;
+    }
+
+    /**
+     * Gets the {@link SCMHead} that the migration applies to.
+     *
+     * @return the {@link SCMHead} that the migration applies to.
+     */
+    public final Class<H> getSCMHeadClass() {
+        return headClass;
+    }
+
+    /**
+     * Perform a migration.
+     * @param source the source instance.
+     * @param head the candidate head.
+     * @return the migrated head or {@code null} if the migration was not appropriate.
+     */
+    @CheckForNull
+    public abstract SCMHead migrate(@NonNull S source, @NonNull H head);
+
+    /**
+     * Perform a migration.
+     * @param source the source instance.
+     * @param revision the candidate revision.
+     * @return the migrated revision or {@code null} if the migration was not appropriate.
+     */
+    @CheckForNull
+    public SCMRevision migrate(@NonNull S source, @NonNull R revision) {
+        return null;
+    }
+
+    /**
+     * Perform a migration.
+     *
+     * @param source the source instance.
+     * @param head   the candidate head.
+     * @return the migrated head or the original head.
+     */
+    @SuppressWarnings("unchecked")
+    @NonNull
+    public static SCMHead readResolveSCMHead(@NonNull SCMSource source, @NonNull SCMHead head) {
+        for (SCMHeadMigration m : ExtensionList.lookup(SCMHeadMigration.class)) {
+            if (m.sourceClass.isInstance(source)
+                    && m.headClass.isInstance(head)) {
+                SCMHead migrated = m.migrate(source, head);
+                if (migrated != null) {
+                    return migrated;
+                }
+            }
+        }
+        return head;
+    }
+    /**
+     * Perform a migration.
+     *
+     * @param source the source instance.
+     * @param revision   the candidate revision.
+     * @return the migrated revision or the original revision.
+     */
+    @SuppressWarnings("unchecked")
+    @CheckForNull
+    public static SCMRevision readResolveSCMRevision(@NonNull SCMSource source, @CheckForNull SCMRevision revision) {
+        if (revision == null) {
+            return null;
+        }
+        SCMHead head = revision.getHead();
+        for (SCMHeadMigration m : ExtensionList.lookup(SCMHeadMigration.class)) {
+            if (m.sourceClass.isInstance(source)
+                    && m.headClass.isInstance(head)
+                    && m.revisionClass.isInstance(revision)) {
+                SCMRevision migrated = m.migrate(source, revision);
+                if (migrated != null) {
+                    return migrated;
+                }
+            }
+        }
+        return revision;
+    }
+}


### PR DESCRIPTION
See [JENKINS-41121](https://issues.jenkins-ci.org/browse/JENKINS-41121) requires matching changes in branch-api and github-branch-source plugins (bitbucket-branch-source is not affected as it already had done the right thing and implemented its own `SCMHead` (though did not store enough information for PRs so all PRs will rebuild and there is nothing we can do as the target branch was not retained)

@reviewbybees

(i'll be linking the downstream PRs to this) 