### PR TITLE
[FIXED JENKINS-42542] SCMHeadObserver.observe(SCMHead,SCMRevision) should be allowed to throw IO and Interrupted exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <artifactId>scm-api</artifactId>
-  <version>2.0.9-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>SCM API Plugin</name>

--- a/src/main/java/jenkins/scm/api/SCMHeadEvent.java
+++ b/src/main/java/jenkins/scm/api/SCMHeadEvent.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Item;
 import hudson.scm.SCM;
 import hudson.triggers.SCMTrigger;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -250,7 +251,8 @@ public abstract class SCMHeadEvent<P> extends SCMEvent<P> {
          * {@inheritDoc}
          */
         @Override
-        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+                throws IOException, InterruptedException {
             if (untrusted.containsKey(head)) {
                 trusted.put(head, revision);
                 untrusted.remove(head);

--- a/src/main/java/jenkins/scm/api/SCMHeadObserver.java
+++ b/src/main/java/jenkins/scm/api/SCMHeadObserver.java
@@ -25,6 +25,7 @@ package jenkins.scm.api;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -45,8 +46,11 @@ public abstract class SCMHeadObserver {
      *
      * @param head     the head.
      * @param revision the revision.
+     * @throws IOException if processing of the observation could not be completed due to an {@link IOException}.
+     * @throws InterruptedException  if processing of the observation was interrupted
      */
-    public abstract void observe(@NonNull SCMHead head, @NonNull SCMRevision revision);
+    public abstract void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+            throws IOException, InterruptedException;
 
     /**
      * Returns information about whether the observer wants more results.
@@ -197,7 +201,8 @@ public abstract class SCMHeadObserver {
          * {@inheritDoc}
          */
         @Override
-        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+                throws IOException, InterruptedException {
             for (SCMHeadObserver observer : observers) {
                 if (observer.isObserving()) {
                     observer.observe(head, revision);
@@ -290,7 +295,8 @@ public abstract class SCMHeadObserver {
          * {@inheritDoc}
          */
         @Override
-        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+                throws IOException, InterruptedException {
             for (SCMHeadObserver observer : observers) {
                 if (observer.isObserving()) {
                     observer.observe(head, revision);
@@ -582,7 +588,8 @@ public abstract class SCMHeadObserver {
          * {@inheritDoc}
          */
         @Override
-        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+                throws IOException, InterruptedException {
             delegate.observe(head, revision);
         }
 
@@ -632,7 +639,8 @@ public abstract class SCMHeadObserver {
          * {@inheritDoc}
          */
         @Override
-        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision)
+                throws IOException, InterruptedException {
             if (remaining.contains(head)) {
                 remaining.remove(head);
                 super.observe(head, revision);

--- a/src/test/java/jenkins/scm/api/SCMEventTest.java
+++ b/src/test/java/jenkins/scm/api/SCMEventTest.java
@@ -209,7 +209,7 @@ public class SCMEventTest {
         Mockito.when(req.getHeader("X-Forwarded-Port")).thenReturn("443");
         Mockito.when(req.getHeader("X-Forwarded-For")).thenReturn("scm.example.com, gateway.example.com, proxy.example.com");
         Mockito.when(req.getRequestURI()).thenReturn("/jenkins/notify");
-        Mockito.when(req.getLocalPort()).thenReturn(8080);
+        Mockito.when(req.getRemotePort()).thenReturn(8080);
         Mockito.when(req.getRemoteHost()).thenReturn(null);
         Mockito.when(req.getRemoteAddr()).thenReturn("203.0.113.1");
         assertThat(SCMEvent.originOf(req), is("scm.example.com → gateway.example.com → proxy.example.com → 203.0.113.1 ⇒ https://jenkins.example.com/jenkins/notify"));


### PR DESCRIPTION
See [JENKINS-42542](https://issues.jenkins-ci.org/browse/JENKINS-42542)

This is strictly speaking a breaking method signature change, the following is the rationale as to why we can make the change with minimal risk:

* _consumers_ of SCM API will be implementing their own subclasses of `SCMHeadObserver`, they will not (outside of unit tests) be calling `SCMHeadObserver.observe()` thus the widening of the method signature will not affect consumers plugin implementations. (though consumers may have test compilation errors when they upgrade their dependency)

* `SCMSource.fetch(...)` (and it's matching SPI, `SCMSource.retrieve(...)`) already declare throwing `IOException` and `InterruptedException` so _implementations_ of SCM API should not be affected by the signature change. At worst implementations will pick up a compiler error when they update their SCM API dependency - though a quick test revealed that git, mercurial, github and Bitbucket SCMSource implementations were all unaffected by the change.

* Running a newer SCM API with an implementation that were compiled against the older SCM API will not cause issues as:

    * Checked exceptions are not enforced at runtime, only at compile time.

    * The calls to `SCMHeadObserver.observe(...)` will all be within `SCMSource.retrieve(...)` which already propagates the same exceptions so consumers will be handling the exceptions anyway.


@reviewbybees