### PR TITLE
[FIXED JENKINS-46356] Get rid of javafx class

### DIFF
--- a/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
@@ -25,7 +25,6 @@
 
 package jenkins.scm.impl.mock;
 
-import com.sun.javafx.collections.UnmodifiableListSet;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
@@ -598,7 +597,7 @@ public class MockSCMController implements Closeable {
             this.hash = hash;
             this.timestamp = timestamp;
             this.message = message;
-            this.files = new UnmodifiableListSet<String>(new ArrayList<String>(files));
+            this.files = Collections.unmodifiableSet(files);
         }
 
         public String getHash() {


### PR DESCRIPTION
[JENKINS-46356](https://issues.jenkins-ci.org/browse/JENKINS-46356)

We didn't need it, and it was causing compilation errors on
default-jdk8-headless. Fun!

Also, fwiw, I verified that Declarative's tests using the functionality this was added with work fine with `Collections.unmodifiableSet` here instead.

cc @reviewbybees