### PR TITLE
WIP [JENKINS-47091] Support matching PR target branches

### DIFF
--- a/src/main/java/jenkins/scm/impl/trait/RegexSCMHeadFilterTrait.java
+++ b/src/main/java/jenkins/scm/impl/trait/RegexSCMHeadFilterTrait.java
@@ -60,6 +60,24 @@ public class RegexSCMHeadFilterTrait extends SCMSourceTrait {
      */
     @CheckForNull
     private transient Pattern pattern;
+    /**
+     * Include pull requests destined for branches matched by this filter.
+     */
+    @NonNull
+    private final boolean includePRDestinationBranch;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param regex the regular expression.
+     * @param includePRDestinationBranch include pull requests destined for branches matched by this filter.
+     */
+    @DataBoundConstructor
+    public RegexSCMHeadFilterTrait(@NonNull String regex, boolean includePRDestinationBranch) {
+        pattern = Pattern.compile(regex);
+        this.regex = regex;
+        this.includePRDestinationBranch = includePRDestinationBranch;
+    }
 
     /**
      * Stapler constructor.
@@ -68,8 +86,7 @@ public class RegexSCMHeadFilterTrait extends SCMSourceTrait {
      */
     @DataBoundConstructor
     public RegexSCMHeadFilterTrait(@NonNull String regex) {
-        pattern = Pattern.compile(regex);
-        this.regex = regex;
+        RegexSCMHeadFilterTrait(regex, false);
     }
 
     /**
@@ -104,6 +121,10 @@ public class RegexSCMHeadFilterTrait extends SCMSourceTrait {
         context.withPrefilter(new SCMHeadPrefilter() {
             @Override
             public boolean isExcluded(@NonNull SCMSource source, @NonNull SCMHead head) {
+                if (includePRDestinationBranch && head instanceof ChangeRequestSCMHead) {
+                    head = ((ChangeRequestSCMHead)head).getTarget();
+                }
+
                 return !getPattern().matcher(head.getName()).matches();
             }
         });

--- a/src/main/java/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait.java
+++ b/src/main/java/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait.java
@@ -59,6 +59,26 @@ public class WildcardSCMHeadFilterTrait extends SCMSourceTrait {
     private final String excludes;
 
     /**
+     * Include pull requests destined for branches matched by this filter.
+     */
+    @NonNull
+    private final boolean includePRDestinationBranch;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param includes the include rules.
+     * @param excludes the exclude rules.
+     * @param includePRDestinationBranch include pull requests destined for branches matched by this filter.
+     */
+    @DataBoundConstructor
+    public WildcardSCMHeadFilterTrait(@CheckForNull String includes, String excludes, boolean includePRDestinationBranch) {
+        this.includes = StringUtils.defaultIfBlank(includes, "*");
+        this.excludes = StringUtils.defaultIfBlank(excludes, "");
+        this.includePRDestinationBranch = includePRDestinationBranch;
+    }
+
+    /**
      * Stapler constructor.
      *
      * @param includes the include rules.
@@ -66,8 +86,7 @@ public class WildcardSCMHeadFilterTrait extends SCMSourceTrait {
      */
     @DataBoundConstructor
     public WildcardSCMHeadFilterTrait(@CheckForNull String includes, String excludes) {
-        this.includes = StringUtils.defaultIfBlank(includes, "*");
-        this.excludes = StringUtils.defaultIfBlank(excludes, "");
+        WildcardSCMHeadFilterTrait(includes, excludes, false);
     }
 
     /**
@@ -96,6 +115,10 @@ public class WildcardSCMHeadFilterTrait extends SCMSourceTrait {
         context.withPrefilter(new SCMHeadPrefilter() {
             @Override
             public boolean isExcluded(@NonNull SCMSource request, @NonNull SCMHead head) {
+                if (includePRDestinationBranch && head instanceof ChangeRequestSCMHead) {
+                    head = ((ChangeRequestSCMHead)head).getTarget();
+                }
+
                 return !Pattern.matches(getPattern(getIncludes()), head.getName())
                         || (Pattern.matches(getPattern(getExcludes()), head.getName()));
             }

--- a/src/main/resources/jenkins/scm/impl/trait/RegexSCMHeadFilterTrait/config.jelly
+++ b/src/main/resources/jenkins/scm/impl/trait/RegexSCMHeadFilterTrait/config.jelly
@@ -26,4 +26,7 @@
   <f:entry title="${%Regular expression}" field="regex">
     <f:textbox default=".*"/>
   </f:entry>
+  <f:entry title="${%Include Pull Requests destined for branches which match this filter.}" field="includePRDestinationBranch">
+    <f:checkbox default="false"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/config.jelly
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/config.jelly
@@ -29,4 +29,7 @@
   <f:entry title="${%Exclude}" field="excludes">
     <f:textbox default=""/>
   </f:entry>
+  <f:entry title="${%Include Pull Requests destined for branches which match this filter.}" field="includePRDestinationBranch">
+    <f:checkbox default="false"/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
This change adds an option for filtering of Pull Requests (PRs) based on targeting the destination branch of the PR matching the regex filter and wildcard filter.

Old behavior is preserved as a default.

TODO:
- [ ] Get some initial feedback from @stephenc and improve based on feedback.
- [ ] Write tests for my proposed change to ensure it won't be broken in the future.