### PR TITLE
[FIXED JENKINS-48571] Ensure we always save after setting SCMSource id.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,6 @@
       <version>1.6</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-multibranch</artifactId>
-      <version>2.16</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.642.3</jenkins.version>
+    <java.level>7</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
 
@@ -105,6 +105,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <version>1.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>1.609.3</jenkins.version>
+    <java.level>6</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
 

--- a/src/main/java/jenkins/scm/api/SCMSource.java
+++ b/src/main/java/jenkins/scm/api/SCMSource.java
@@ -75,6 +75,8 @@ import org.kohsuke.stapler.DataBoundSetter;
 public abstract class SCMSource extends AbstractDescribableImpl<SCMSource>
         implements ExtensionPoint {
 
+    private static final Logger LOGGER = Logger.getLogger(SCMSource.class.getName());
+
     /**
      * Replaceable pronoun of that points to a {@link SCMSource}. Defaults to {@code null} depending on the context.
      * @since 2.0
@@ -197,10 +199,17 @@ public abstract class SCMSource extends AbstractDescribableImpl<SCMSource>
      */
     @NonNull
     public final synchronized String getId() {
-        if (id == null) {
-            id = UUID.randomUUID().toString();
+        if (this.id == null) {
+            this.id = UUID.randomUUID().toString();
+            if (owner != null) {
+                try {
+                    owner.save();
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Could not save owner of SCMSource: " + e, e);
+                }
+            }
         }
-        return id;
+        return this.id;
     }
 
     /**

--- a/src/test/java/jenkins/scm/impl/PersistAcrossRestartsTest.java
+++ b/src/test/java/jenkins/scm/impl/PersistAcrossRestartsTest.java
@@ -1,0 +1,95 @@
+package jenkins.scm.impl;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.FreeStyleProject;
+import hudson.model.InvisibleAction;
+import hudson.model.TaskListener;
+import hudson.scm.NullSCM;
+import hudson.scm.SCM;
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class PersistAcrossRestartsTest {
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-48571")
+    @Test
+    public void uuidIdPersists() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                BogusSCMSource source = new BogusSCMSource();
+                BranchSource branchSource = new BranchSource(source);
+                WorkflowMultiBranchProject p = story.j.jenkins.createProject(WorkflowMultiBranchProject.class, "test-with-source");
+                p.setSourcesList(Collections.singletonList(branchSource));
+
+                // TODO: Find a better way to persist this for testing across restart.
+                FreeStyleProject p2 = story.j.createFreeStyleProject("test-without-source");
+                p2.setDescription(source.getId());
+            }
+        });
+
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowMultiBranchProject p = (WorkflowMultiBranchProject) story.j.jenkins.getItem("test-with-source");
+                FreeStyleProject p2 = (FreeStyleProject)story.j.jenkins.getItem("test-without-source");
+                assertNotNull(p);
+                assertNotNull(p2);
+                SCMSource source = p.getSCMSource(p2.getDescription());
+                assertNotNull(source);
+                assertFalse(source instanceof NullSCMSource);
+            }
+        });
+    }
+
+    public static class BogusSCMSource extends SCMSource {
+        /**
+         * Constructor.
+         */
+        public BogusSCMSource() {
+            super();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected void retrieve(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer,
+                                @CheckForNull SCMHeadEvent<?> event, @NonNull TaskListener listener)
+                throws IOException, InterruptedException {
+
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public SCM build(@NonNull SCMHead head, @CheckForNull SCMRevision revision) {
+            return new NullSCM();
+        }
+
+
+    }
+}


### PR DESCRIPTION
[JENKINS-48571](https://issues.jenkins-ci.org/browse/JENKINS-48571)

I don't love using workflow-multibranch for the test, but that was the
easiest way I could find to reproduce the error. I'm also not sure if
the way I'm saving is actually the best approach.

cc @reviewbybees 