### PR TITLE
Discussion for AccuRev Implementation

### DIFF
--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -357,6 +357,18 @@ public class AccurevSCMSource extends SCMSource {
                     new NonLocalizable("Streams")
                     // Better: Messages._AccurevSCMSource_StreamHeadCategory()
                 ),
+                new UncategorizedSCMSourceCategory(
+                    new NonLocalizable("Gated Streams")
+                    // Better: Messages._AccurevSCMSource_GatedStreamHeadCategory()
+                ),
+                new ChangeRequestSCMHeadCategory(
+                    new NonLocalizable("Staging streams")
+                    // Better: Messages._AccurevSCMSource_StreamHeadCategory()
+                )
+                new ChangeRequestSCMHeadCategory(
+                    new NonLocalizable("Workspace")
+                    // Better: Messages._AccurevSCMSource_StreamHeadCategory()
+                ),
                 new TagSCMHeadCategory(
                     new NonLocalizable("Snapshots")
                     // Better: Messages._AccurevSCMSource_SnapshotHeadCategory()

--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -362,12 +362,12 @@ public class AccurevSCMSource extends SCMSource {
                     // Better: Messages._AccurevSCMSource_GatedStreamHeadCategory()
                 ),
                 new ChangeRequestSCMHeadCategory(
-                    new NonLocalizable("Staging streams")
-                    // Better: Messages._AccurevSCMSource_StreamHeadCategory()
+                    new NonLocalizable("Staging Streams")
+                    // Better: Messages._AccurevSCMSource_StagingStreamHeadCategory()
                 )
                 new ChangeRequestSCMHeadCategory(
-                    new NonLocalizable("Workspace")
-                    // Better: Messages._AccurevSCMSource_StreamHeadCategory()
+                    new NonLocalizable("Workspaces")
+                    // Better: Messages._AccurevSCMSource_WorkSpaceHeadCategory()
                 ),
                 new TagSCMHeadCategory(
                     new NonLocalizable("Snapshots")


### PR DESCRIPTION
Created PR to start a discussion about implementation for AccuRev.

My thoughts so far are to create SCM Source with the following.
Should I implement new HeadCategory to easier different between Workspaces and Staging streams?
For instance, for `StagingStreamDiscoveryTrait` you might want to consider workspaces directly below the Staging Stream depending on the build strategy on the trait. Yet ignore all other workspaces in the stream tree.
You might have something committed to the workspace (AccuRev terms kept or defunct) which would be the reason to build workspaces below a staging stream.

And for `WorkspaceDiscoveryTrait` you will definitely ignore workspaces connected to staging streams yet build rest.

Still, have a lot of work to do with implementing webhook sent and receive on the AccuRev server and share that 😢 