### PR TITLE
Mention space separator in exclusions by name help file

### DIFF
--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/help-excludes.html
@@ -23,6 +23,6 @@
  -->
 <div>
     Name patterns (separated by space) to ignore even if matched by the includes list.
-    For example: <code>release</code><br/>
+    For example: <code>release alpha-* beta-*</code><br/>
     <strong>NOTE: this filter will be applied to all branch like things, including change requests</strong>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMHeadFilterTrait/help-excludes.html
@@ -22,7 +22,7 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    Name patterns to ignore even if matched by the includes list.
+    Name patterns (separated by space) to ignore even if matched by the includes list.
     For example: <code>release</code><br/>
     <strong>NOTE: this filter will be applied to all branch like things, including change requests</strong>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
@@ -22,6 +22,6 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    Project name patterns to ignore even if matched by the includes list.
+    Project name patterns (separated by space) to ignore even if matched by the includes list.
     For example: <code>release</code>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
@@ -23,5 +23,5 @@
  -->
 <div>
     Project name patterns (separated by space) to ignore even if matched by the includes list.
-    For example: <code>release alpha-* beta-*</code>
+    For example: <code>jenkins *-plugin</code>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
@@ -23,5 +23,5 @@
  -->
 <div>
     Project name patterns (separated by space) to ignore even if matched by the includes list.
-    For example: <code>release</code>
+    For example: <code>release alpha-* beta-*</code>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-excludes.html
@@ -22,6 +22,6 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    Project name patterns (separated by space) to ignore even if matched by the includes list.
+    Space-separated list of project name patterns to ignore even if matched by the includes list.
     For example: <code>jenkins *-plugin</code>
 </div>

--- a/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-includes.html
+++ b/src/main/resources/jenkins/scm/impl/trait/WildcardSCMSourceFilterTrait/help-includes.html
@@ -23,5 +23,5 @@
  -->
 <div>
     Space-separated list of project name patterns to consider.
-    You may use <code>*</code> as a wildcard; for example: <code>master release*</code>
+    You may use <code>*</code> as a wildcard; for example: <code>jenkins *-plugin</code>
 </div>


### PR DESCRIPTION
### What has been done
It's not very obvious how to specify multiple name patterns. Adding this information to help file should help.

💡 ~Should we update the pattern example as well?~ - YES