### PR TITLE
[JENKINS-50777] Expose SCMRevisionAction and associated metadata via Stapler export

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMHeadOrigin.java
+++ b/src/main/java/jenkins/scm/api/SCMHeadOrigin.java
@@ -27,6 +27,8 @@ package jenkins.scm.api;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Represents the origin of a {@link SCMHead}.
@@ -43,6 +45,7 @@ import java.io.Serializable;
  *
  * @since 2.2.0
  */
+@ExportedBean
 public abstract class SCMHeadOrigin implements Serializable {
 
     /**
@@ -173,6 +176,7 @@ public abstract class SCMHeadOrigin implements Serializable {
          *
          * @return the name of this fork.
          */
+        @Exported
         @NonNull
         public String getName() {
             return name;

--- a/src/main/java/jenkins/scm/api/SCMRevision.java
+++ b/src/main/java/jenkins/scm/api/SCMRevision.java
@@ -26,12 +26,15 @@ package jenkins.scm.api;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.Serializable;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Base class that represents a specific (or not so specific) revision of a {@link SCMHead}.
  *
  * @author Stephen Connolly
  */
+@ExportedBean
 public abstract class SCMRevision implements Serializable {
 
     /**
@@ -78,6 +81,7 @@ public abstract class SCMRevision implements Serializable {
      *
      * @return {@code true} if and only if this revision is deterministic.
      */
+    @Exported
     public boolean isDeterministic() {
         return true;
     }
@@ -87,6 +91,7 @@ public abstract class SCMRevision implements Serializable {
      *
      * @return the {@link SCMHead} that this {@link SCMRevision} belongs to.
      */
+    @Exported
     @NonNull
     public final SCMHead getHead() {
         return head;

--- a/src/main/java/jenkins/scm/api/SCMRevisionAction.java
+++ b/src/main/java/jenkins/scm/api/SCMRevisionAction.java
@@ -32,11 +32,14 @@ import hudson.model.Actionable;
 import hudson.model.InvisibleAction;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * {@link Action} added to {@link AbstractBuild} to remember
  * which revision is built in the given build.
  */
+@ExportedBean
 public class SCMRevisionAction extends InvisibleAction {
     /**
      * The {@link SCMSource#getId()} or {@code null} for legacy instances.
@@ -91,6 +94,7 @@ public class SCMRevisionAction extends InvisibleAction {
      *
      * @return the {@link SCMRevision}.
      */
+    @Exported
     @NonNull
     public SCMRevision getRevision() {
         return revision;

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMRevision.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMRevision.java
@@ -73,6 +73,7 @@ public abstract class ChangeRequestSCMRevision<H extends SCMHead & ChangeRequest
      * revision {@code false} if the effective revision ignores the {@link #getTarget()}.
      * @see ChangeRequestSCMHead2
      */
+    @Exported
     public final boolean isMerge() {
         SCMHead head = getHead();
         return !(head instanceof ChangeRequestSCMHead2)


### PR DESCRIPTION
[JENKINS-50777](https://issues.jenkins-ci.org/browse/JENKINS-50777)

Example output with https://github.com/jenkinsci/git-plugin/pull/581 + https://github.com/jenkinsci/github-branch-source-plugin/pull/180 on a `master` build:

```json
{
  "_class" : "jenkins.scm.api.SCMRevisionAction",
  "revision" : {
    "_class" : "jenkins.plugins.git.AbstractGitSCMSource$SCMRevisionImpl",
    "deterministic" : true,
    "head" : {
      "_class" : "org.jenkinsci.plugins.github_branch_source.BranchSCMHead",
      "name" : "master",
      "origin" : {
        "_class" : "jenkins.scm.api.SCMHeadOrigin$Default"
      }
    },
    "hash" : "c9e8148ede406f8ad89610befbdf51ba4a0ef24a"
  }
}
```

and on a PR merge build, specifically https://github.com/cloudbeers/PR-demo/pull/20:

```json
{
  "_class" : "jenkins.scm.api.SCMRevisionAction",
  "revision" : {
    "_class" : "org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision",
    "deterministic" : true,
    "head" : {
      "_class" : "org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead",
      "name" : "PR-20",
      "origin" : {
        "_class" : "jenkins.scm.api.SCMHeadOrigin$Fork",
        "name" : "vivek"
      }
    },
    "merge" : true,
    "target" : {
      "_class" : "jenkins.plugins.git.AbstractGitSCMSource$SCMRevisionImpl",
      "deterministic" : true,
      "head" : {
        "_class" : "org.jenkinsci.plugins.github_branch_source.BranchSCMHead",
        "name" : "master",
        "origin" : {
          "_class" : "jenkins.scm.api.SCMHeadOrigin$Default"
        }
      },
      "hash" : "c9e8148ede406f8ad89610befbdf51ba4a0ef24a"
    },
    "pullHash" : "5d2f682bc7a77f253e9b887536fa08f7ba41af64"
  }
}
```

Example of extracting important fields from a build URL:

    …/job/…/…/api/json?tree=actions[revision[hash,pullHash]]