### PR TITLE
[JENKINS-52964] Add SCMFileSystem.supports(SCMSourceDescriptor)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.21</version>
+    <version>3.24</version>
     <relativePath />
   </parent>
 
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <revision>2.2.9</revision>
+    <revision>2.3.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.7.3</jenkins.version>
     <java.level>7</java.level>

--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -34,6 +34,7 @@ import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
 import java.io.Closeable;
 import java.io.File;
@@ -365,6 +366,31 @@ public abstract class SCMFileSystem implements Closeable {
     }
 
     /**
+     * Given a {@link SCMDescriptor} this method will check if there is at least one {@link SCMFileSystem} provider
+     * capable of being instantiated from the descriptor's {@link SCMSource}. Returning {@code true} does not mean that
+     * {@link #of(Item, SCM, SCMRevision)} will be able to instantiate a {@link SCMFileSystem} for any specific
+     * {@link Item} or {@link SCMRevision}, rather returning {@code false} indicates that there is absolutely no point
+     * in calling {@link #of(Item, SCM, SCMRevision)} as it will always return {@code null}.
+     *
+     * @param descriptor the {@link SCMDescriptor}.
+     * @return {@code true} if {@link #of(Item, SCM, SCMRevision)} could return a {@link SCMFileSystem} implementation,
+     * {@code false} if {@link #of(Item, SCM, SCMRevision)} will always return {@code null} for the supplied {@link SCM}.
+     * @since 2.3.0
+     */
+    public static boolean supports(@NonNull SCMDescriptor descriptor) {
+        descriptor.getClass(); // throw NPE if null
+        if (descriptor.clazz == null) {
+            throw new NullPointerException();
+        }
+        for (Builder b : ExtensionList.lookup(Builder.class)) {
+            if (b.supports(descriptor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Given a {@link SCMSourceDescriptor} this method will check if there is at least one {@link SCMFileSystem} provider
      * capable of being instantiated from the descriptor's {@link SCMSource}. Returning {@code true} does not mean that
      * {@link #of(SCMSource, SCMHead, SCMRevision)} will be able to instantiate a {@link SCMFileSystem} for any specific
@@ -375,7 +401,7 @@ public abstract class SCMFileSystem implements Closeable {
      * @return {@code true} if {@link #of(SCMSource, SCMHead)} / {@link #of(SCMSource, SCMHead, SCMRevision)} could
      * return a {@link SCMFileSystem} implementation, {@code false} if {@link #of(SCMSource, SCMHead)} /
      * {@link #of(SCMSource, SCMHead, SCMRevision)} will always return {@code null} for the supplied {@link SCMSource}.
-     * @since 2.0
+     * @since 2.3.0
      */
     public static boolean supports(@NonNull SCMSourceDescriptor descriptor) {
         descriptor.getClass(); // throw NPE if null
@@ -389,6 +415,7 @@ public abstract class SCMFileSystem implements Closeable {
         }
         return false;
     }
+
     /**
      * Extension point that allows different plugins to implement {@link SCMFileSystem} classes for the same {@link SCM}
      * or {@link SCMSource} and let Jenkins pick the most capable for any specific {@link SCM} implementation.
@@ -415,6 +442,36 @@ public abstract class SCMFileSystem implements Closeable {
         public abstract boolean supports(SCMSource source);
 
         /**
+         * Checks if this {@link Builder} supports the supplied {@link SCMDescriptor}.
+         *
+         * @param descriptor the {@link SCMDescriptor}
+         * @return the return value of {@link #supportsDescriptor(SCMDescriptor)} if implemented, otherwise, it
+         * will return true if one of the following is true: the {@link SCM} for the descriptor is the enclosing
+         * class of this builder class, the builder and {@link SCM} are in the same package, or the builder is in
+         * a child package of the {@link SCM}.
+         * @since 2.3.0
+         */
+        public final boolean supports(SCMDescriptor<?> descriptor) {
+            if (Util.isOverridden(SCMFileSystem.Builder.class, getClass(), "supportsDescriptor", SCMDescriptor.class)) {
+                return supportsDescriptor(descriptor);
+            } else {
+                return descriptor.clazz.isAssignableFrom((getClass().getEnclosingClass())) ||
+                        getClass().getPackage().equals(descriptor.clazz.getPackage()) ||
+                        getClass().getPackage().getName().startsWith(descriptor.clazz.getPackage().getName());
+            }
+        }
+
+        /**
+         * Checks if this {@link Builder} supports the supplied {@link SCMDescriptor}.
+         *
+         * @param descriptor the {@link SCMDescriptor}
+         * @return {@code true} if and only if the supplied {@link SCMSourceDescriptor}'s {@link SCMDescriptor} class is
+         * supported by this {@link Builder}.
+         * @since 2.3.0
+         */
+        protected abstract boolean supportsDescriptor(SCMDescriptor descriptor);
+
+        /**
          * Checks if this {@link Builder} supports the supplied {@link SCMSourceDescriptor}.
          *
          * @param descriptor the {@link SCMSourceDescriptor}
@@ -422,6 +479,7 @@ public abstract class SCMFileSystem implements Closeable {
          * will return true if one of the following is true: the {@link SCMSource} for the descriptor is the enclosing
          * class of this builder class, the builder and {@link SCMSource} are in the same package, or the builder is in
          * a child package of the {@link SCMSource}.
+         * @since 2.3.0
          */
         public final boolean supports(SCMSourceDescriptor descriptor) {
             if (Util.isOverridden(SCMFileSystem.Builder.class, getClass(), "supportsDescriptor", SCMSourceDescriptor.class)) {
@@ -440,6 +498,7 @@ public abstract class SCMFileSystem implements Closeable {
          * @return {@code true} if and only if the supplied {@link SCMSourceDescriptor}'s {@link SCMSource} class is
          * supported by this {@link Builder}, {@code false} if {@link #build(SCMSource, SCMHead, SCMRevision)} will
          * <strong>always</strong> return {@code null}, and {@code false} by default for compatibility.
+         * @since 2.3.0
          */
         protected abstract boolean supportsDescriptor(SCMSourceDescriptor descriptor);
 

--- a/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
+++ b/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.scm.impl;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Item;
+import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
+import jenkins.scm.api.SCMFileSystem;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
+import jenkins.scm.impl.mock.MockSCM;
+import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SCMFileSystemTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_false_by_default_for_descriptor() {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(MockSCMSource.DescriptorImpl.class);
+
+        assertFalse(SCMFileSystem.supports(descriptor));
+
+        SCMDescriptor scmDescriptor = r.jenkins.getDescriptorByType(MockSCM.DescriptorImpl.class);
+
+        assertFalse(SCMFileSystem.supports(scmDescriptor));
+    }
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_true_implementation_for_descriptor() {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(MockSCMSource.DescriptorImpl.class);
+
+        assertTrue(SCMFileSystem.supports(descriptor));
+
+        SCMDescriptor scmDescriptor = r.jenkins.getDescriptorByType(MockSCM.DescriptorImpl.class);
+
+        assertTrue(SCMFileSystem.supports(scmDescriptor));
+    }
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_false_implementation_for_descriptor() {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(MockSCMSource.DescriptorImpl.class);
+
+        assertFalse(SCMFileSystem.supports(descriptor));
+
+        SCMDescriptor scmDescriptor = r.jenkins.getDescriptorByType(MockSCM.DescriptorImpl.class);
+
+        assertFalse(SCMFileSystem.supports(scmDescriptor));
+    }
+
+    @TestExtension("filesystem_supports_true_implementation_for_descriptor")
+    public static class TrueBuilder extends SCMFileSystem.Builder {
+        @Override
+        public boolean supports(SCM source) {
+            return source instanceof MockSCM;
+        }
+
+        @Override
+        public boolean supports(SCMSource source) {
+            return source instanceof MockSCMSource;
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMDescriptor descriptor) {
+            System.err.println("SUP: " + descriptor);
+            return descriptor instanceof MockSCM.DescriptorImpl;
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
+            System.err.println("SRC SUP: " + descriptor);
+            return descriptor instanceof MockSCMSource.DescriptorImpl;
+        }
+
+        @Override
+        @CheckForNull
+        public SCMFileSystem build(@NonNull Item owner, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return null;
+        }
+
+    }
+
+    @TestExtension("filesystem_supports_false_implementation_for_descriptor")
+    public static class FalseBuilder extends SCMFileSystem.Builder {
+        @Override
+        public boolean supports(SCM source) {
+            return !(source instanceof MockSCM);
+        }
+
+        @Override
+        public boolean supports(SCMSource source) {
+            return !(source instanceof MockSCMSource);
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMDescriptor descriptor) {
+            return !(descriptor instanceof MockSCM.DescriptorImpl);
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
+            return !(descriptor instanceof MockSCMSource.DescriptorImpl);
+        }
+
+        @Override
+        @CheckForNull
+        public SCMFileSystem build(@NonNull Item owner, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return null;
+        }
+
+    }
+}

--- a/src/test/java/jenkins/scm/impl/SingleSCMSourceTest.java
+++ b/src/test/java/jenkins/scm/impl/SingleSCMSourceTest.java
@@ -32,11 +32,13 @@ import hudson.scm.NullSCM;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import java.util.Map;
+import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.SCMSourceDescriptor;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.impl.mock.MockSCM;
 import jenkins.scm.impl.mock.MockSCMController;
@@ -44,6 +46,7 @@ import jenkins.scm.impl.mock.MockSCMHead;
 import org.hamcrest.Matcher;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -56,6 +59,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.inOrder;
@@ -218,6 +222,14 @@ public class SingleSCMSourceTest {
         when(descriptor.isApplicable(Matchers.any(Descriptor.class))).thenReturn(true);
         assertThat(SingleSCMSource.DescriptorImpl.getSCMDescriptors(owner),
                 (Matcher) hasItem(instanceOf(MockSCM.DescriptorImpl.class)));
+    }
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_false_by_default_for_descriptor() {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(SingleSCMSource.DescriptorImpl.class);
+
+        assertFalse(SCMFileSystem.supports(descriptor));
     }
 
     public interface TopLevelSCMOwner extends TopLevelItem, SCMSourceOwner {

--- a/src/test/java/jenkins/scm/impl/SingleSCMSourceTest.java
+++ b/src/test/java/jenkins/scm/impl/SingleSCMSourceTest.java
@@ -32,13 +32,11 @@ import hudson.scm.NullSCM;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import java.util.Map;
-import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
-import jenkins.scm.api.SCMSourceDescriptor;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.impl.mock.MockSCM;
 import jenkins.scm.impl.mock.MockSCMController;
@@ -46,7 +44,6 @@ import jenkins.scm.impl.mock.MockSCMHead;
 import org.hamcrest.Matcher;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -59,7 +56,6 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.inOrder;
@@ -222,14 +218,6 @@ public class SingleSCMSourceTest {
         when(descriptor.isApplicable(Matchers.any(Descriptor.class))).thenReturn(true);
         assertThat(SingleSCMSource.DescriptorImpl.getSCMDescriptors(owner),
                 (Matcher) hasItem(instanceOf(MockSCM.DescriptorImpl.class)));
-    }
-
-    @Issue("JENKINS-52964")
-    @Test
-    public void filesystem_supports_false_by_default_for_descriptor() {
-        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(SingleSCMSource.DescriptorImpl.class);
-
-        assertFalse(SCMFileSystem.supports(descriptor));
     }
 
     public interface TopLevelSCMOwner extends TopLevelItem, SCMSourceOwner {

--- a/src/test/java/jenkins/scm/impl/mock/MockSCMFile.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMFile.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.scm.impl.mock;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+public class MockSCMFile extends SCMFile {
+    public MockSCMFile() {
+        super();
+    }
+
+    @Override
+    @NonNull
+    public SCMFile newChild(@NonNull String name, boolean assumeIsDirectory) {
+        return new MockSCMFile();
+    }
+
+    @Override
+    @NonNull
+    public Iterable<SCMFile> children() throws IOException, InterruptedException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public long lastModified() throws IOException, InterruptedException {
+        return 1;
+    }
+
+    @Override
+    @NonNull
+    public Type type() throws IOException, InterruptedException {
+        return Type.OTHER;
+    }
+
+    @Override
+    @NonNull
+    public InputStream content() throws IOException, InterruptedException {
+        return new ByteArrayInputStream("no content".getBytes());
+    }
+
+}

--- a/src/test/java/jenkins/scm/impl/mock/MockSCMFileSystem.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMFileSystem.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.scm.impl.mock;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
+import jenkins.scm.api.SCMFile;
+import jenkins.scm.api.SCMFileSystem;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
+
+import java.io.IOException;
+
+public class MockSCMFileSystem extends SCMFileSystem {
+    public MockSCMFileSystem(@CheckForNull SCMRevision rev) {
+        super(rev);
+    }
+
+    @Override
+    public long lastModified() throws IOException, InterruptedException {
+        return 1;
+    }
+
+    @NonNull
+    public SCMFile getRoot() {
+        return new MockSCMFile();
+    }
+}


### PR DESCRIPTION
[JENKINS-52964](https://issues.jenkins.io/browse/JENKINS-52964)

It's a pain that we can't tell whether a given `SCMSource`
implementation can support an `SCMFileSystem` without having an actual
instance of the `SCMSource` - that makes it impossible, for example,
to filter a list of possible `SCMSource`s in a configuration UI to
just those which support `SCMFileSystem`.

This is a proposed way to address that - add
`SCMFileSystem.Builder#supports(SCMSourceDescriptor)`, and
`SCMFileSystem#supports(SCMSourceDescriptor)`. The `Builder` method
will return false unless overridden, to preserve compatibility, and
it's up to individual `Builder` implementations to decide whether they
want to say "yes, the corresponding `SCMSource` for this
`SCMSourceDescriptor` is supported" without an actual instance to
check against for more details.

(downstream PRs consuming this incoming shortly)