### PR TITLE
Using own executor service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <revision>2.4.2</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.107.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
   </scm>
 
   <properties>
-    <revision>2.4.2</revision>
+    <revision>2.5.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.107.1</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>

--- a/src/main/java/jenkins/scm/api/SCMEvent.java
+++ b/src/main/java/jenkins/scm/api/SCMEvent.java
@@ -41,8 +41,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.servlet.http.HttpServletRequest;
 
+import hudson.util.ClassLoaderSanityThreadFactory;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
+import jenkins.security.ImpersonatingScheduledExecutorService;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
@@ -210,7 +212,7 @@ public abstract class SCMEvent<P> {
         if (executorService == null) {
             // corePoolSize is set to 10, but will only be created if needed.
             // ScheduledThreadPoolExecutor "acts as a fixed-sized pool using corePoolSize threads"
-            executorService =  new ScheduledThreadPoolExecutor(10, new NamingThreadFactory(new DaemonThreadFactory(), "SCMEvent"));
+            executorService = new ImpersonatingScheduledExecutorService(new ScheduledThreadPoolExecutor(10, new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "SCMEvent")), ACL.SYSTEM);
         }
         return executorService;
     }


### PR DESCRIPTION
In our company we have Jenkins with ~ 1000 repos in GitHub.
Most of them have a lot of tags (> 1k is standard, moved from old SCMs, but we cannot remove them so far)
Because of that processing events can take a loot of time, and Timer pool is really often all being used for event, which turns our jenkins into vegetable.