### PR TITLE
JENKINS-55424 - Putting a space at the end of Script Path causes java.io.FileNotFoundException

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMFile.java
+++ b/src/main/java/jenkins/scm/api/SCMFile.java
@@ -337,7 +337,7 @@ public abstract class SCMFile {
     public String contentAsString() throws IOException, InterruptedException {
         final InputStream is = content();
         try {
-            return IOUtils.toString(is, contentEncoding());
+            return IOUtils.toString(is, contentEncoding()).trim();
         } finally {
             IOUtils.closeQuietly(is);
         }


### PR DESCRIPTION
See [JENKINS-55424](https://issues.jenkins-ci.org/browse/JENKINS-55424?jql=project%20%3D%20JENKINS%20AND%20assignee%20in%20(sagarailani)).

**Proposed Changelog entries**
- `Internal:` Trimmed Spaces at start and end of the fields.

**Submitter Checklist**

- [x] JIRA issue is well described

- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).

- ~~Appropriate autotests or explanation to why this change has no tests~~

- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

**Desired Reviewers**
@jenkinsci/code-reviewers