### PR TITLE
Make the plugin Java 11 ready -- Remove JAXB usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.24</version>
+    <version>3.40</version>
     <relativePath />
   </parent>
 
@@ -67,8 +67,8 @@
   <properties>
     <revision>2.3.2</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.7.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <revision>2.3.2</revision>
+    <revision>2.4.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>

--- a/src/main/java/jenkins/scm/impl/form/NamedArrayList.java
+++ b/src/main/java/jenkins/scm/impl/form/NamedArrayList.java
@@ -26,6 +26,8 @@ package jenkins.scm.impl.form;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +40,8 @@ import java.util.List;
  *
  * @param <E> the type of element.
  */
+@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS",
+        justification = "On purpose ignoring 'name' field, not changing current behavior present since ~2 years")
 public class NamedArrayList<E> extends ArrayList<E> {
     /**
      * The associated name.

--- a/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
@@ -50,11 +50,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMNavigatorOwner;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.hudson.test.recipes.LocalData;
-
-import javax.xml.bind.DatatypeConverter;
 
 public class MockSCMController implements Closeable {
 
@@ -613,7 +612,7 @@ public class MockSCMController implements Closeable {
     }
 
     static String toHexBinary(byte[] bytes) {
-        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+        return new String(Hex.encodeHex(bytes));
     }
 
     public static final class LogEntry {

--- a/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMController.java
@@ -54,6 +54,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.hudson.test.recipes.LocalData;
 
+import javax.xml.bind.DatatypeConverter;
+
 public class MockSCMController implements Closeable {
 
     private static Map<String, MockSCMController> instances = new WeakHashMap<String, MockSCMController>();
@@ -601,13 +603,17 @@ public class MockSCMController implements Closeable {
                         sha.update(e.getKey().getBytes(StandardCharsets.UTF_8));
                         sha.update(e.getValue());
                     }
-                    hash = javax.xml.bind.DatatypeConverter.printHexBinary(sha.digest()).toLowerCase();
+                    this.hash = toHexBinary(sha.digest());
                 } catch (NoSuchAlgorithmException e) {
                     throw new IllegalStateException("SHA-1 message digest mandated by JLS");
                 }
             }
             return hash;
         }
+    }
+
+    static String toHexBinary(byte[] bytes) {
+        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
     }
 
     public static final class LogEntry {

--- a/src/test/java/jenkins/scm/impl/mock/MockSCMControllerTest.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockSCMControllerTest.java
@@ -1,0 +1,17 @@
+package jenkins.scm.impl.mock;
+
+import org.junit.Test;
+
+import java.security.MessageDigest;
+
+import static org.junit.Assert.assertEquals;
+
+public class MockSCMControllerTest {
+
+    @Test
+    public void toHexBinary() throws Exception {
+        final MessageDigest msg = MessageDigest.getInstance("SHA-1");
+        msg.update("blah".getBytes());
+        assertEquals("5bf1fd927dfb8679496a2e6cf00cbe50c1c87145", MockSCMController.toHexBinary(msg.digest()));
+    }
+}


### PR DESCRIPTION
`mvn -V clean verify -Djenkins.version=2.164.1` works with this fix, both on a JDK8 and JDK11.

@jenkinsci/java11-support 