### PR TITLE
Don't fail SCMName detection on non-IDN host names

### DIFF
--- a/src/test/java/jenkins/scm/api/SCMNameTest.java
+++ b/src/test/java/jenkins/scm/api/SCMNameTest.java
@@ -68,4 +68,9 @@ public class SCMNameTest {
         assertThat(SCMName.fromUrl("http://\u4F8B\u5B50.\u4E2D\u56FD/"), is("\u4F8B\u5B50"));
     }
 
+    @Test
+    public void given__url_with_ipv4address__when__naming__then__no_name_inferred() throws Exception {
+        assertThat(SCMName.fromUrl("http://127.0.0.1/scm"), is(nullValue()));
+    }
+
 }


### PR DESCRIPTION
Previously, when passing an URL with a host name that is not a valid IDN to SCMName::from, it failed with an IllegalArgumentException. This especially affects the case when the host name is an IP address. Make this method a bit more graceful by returning null instead.