### PR TITLE
[JENKINS-43802] Allow fetch/fetchRevisions to be given an Item context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <revision>2.4.2</revision>
+    <revision>2.5.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>


### PR DESCRIPTION
Needed for [JENKINS-43802](https://issues.jenkins-ci.org/browse/JENKINS-43802).

I thought of adding a builder field to `SCMSourceContext` / `SCMSourceRequest` but these seem heavily tied to branch scanning, whereas this is a different use case, for libraries. I also thought of adding something like

```java
/**
 * Allows this to be associated with a particular context, such as a job in which a build is running.
 * If defined, should be considered to supersede {@link #getOwner}
 * for purposes of {@link #retrieve(String, TaskListener)}, {@link #retrieveRevisions(TaskListener)}, etc.
 * @param context a context, such as a folder or job
 * @return {@code this} by default; may be overridden to create a <em>new</em> object with a copy of this configuration
 */
public @NonNull SCMSource withContext(@CheckForNull Item context) {
    return this;
}
```

which could even have a default implementation using either `DescribableModel` or `Cloneable` to make a copy of the original object, offering a `protected Item getContext()` to subclasses, but this seemed to just be perpetuating the antipattern of having critical parameters to a method be injected magically from some `owner` field, so I decided to keep it simple and just introduce new overloads for what I needed. Alternate design suggestions would certainly be considered.