### PR TITLE
Fix javadoc failure on JDK 11.0.3 with parent pom 3.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Fix javadoc build failure on JDK 11.0.3