### PR TITLE
[JENKINS-43802] Alternative implementation

### DIFF
--- a/docs/consumer.adoc
+++ b/docs/consumer.adoc
@@ -242,6 +242,21 @@ TIP: In plain english, when you trigger a build of a job for a `SCMRevision` you
 +
 For example, a Git `SCMSource` might return _Repository_, an Accurev `SCMSource` might return _Depot_, a CVS `SCMSource` might return _Module_ while a Subversion `SCMSource` could return _Repository_ or perhaps even something more generic like _Project_ depending on the way in which the Subversion server is being used footnote:[Do you create one `trunk|branches|tags` per repository or do you use a single big repository and create many `_project_/(trunk|branches|tags)` in that single repository?].
 
+[NOTE]
+====
+There are some rare but legitimate cases where a `SCMSource` needs to be owned by a `Item` that cannot extend `SCMSourceOwner`.
+For example, if you were implementing a `JobProperty` (or an `Action`, etc) that resolves information from a `SCMSource` then the owning item could be `FreeStyleProject` but, as that comes from Jenkins core, we cannot add the `SCMSourceOwner` interface.
+
+In such cases you can use the `SCMSourceOwner.proxyFromItem(item,proxyGetter,sourceSupplier,criteriaSupplier)`.
+
+There are two kinds of proxy that can be returned:
+
+. Requesting a proxy with a `null` `Function<Item,SCMSourceOwner>` indicates that this proxy will not receive `SCMEvent` notification.
+You may choose to either use the proxy owner as a single-shot owner, or attach it to the `Item` by storing as a `transient` field in some linking object (i.e. `Action`, `JobProperty`, etc) attached to the `Item`.
+
+. Requesting a proxy with a non-`null` `Function<Item,SCMSourceOwner>` indicates that the proxy will be stored as a `transient` field in some linking object attached to the `Item` and that the owned sources are interested in receiving events.
+====
+
 === Using SCMNavigator instances
 
 If you implement `jenkins.scm.api.SCMNavigatorOwner` your implementation *must*:

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
       <version>1.9</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>

--- a/src/main/java/jenkins/scm/api/SCMSourceOwner.java
+++ b/src/main/java/jenkins/scm/api/SCMSourceOwner.java
@@ -23,12 +23,47 @@
  */
 package jenkins.scm.api;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.Util;
+import hudson.model.BuildableItem;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Describable;
+import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.JobProperty;
+import hudson.model.Queue;
 import hudson.model.TaskListener;
+import hudson.model.TopLevelItem;
+import hudson.model.listeners.ItemListener;
+import hudson.util.ListBoxModel;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import jenkins.model.Jenkins;
+import net.jcip.annotations.GuardedBy;
+import org.acegisecurity.Authentication;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * An {@link Item} that owns {@link SCMSource} instances. Any {@link SCMSource} instances accessed through a
@@ -86,4 +121,447 @@ public interface SCMSourceOwner extends Item {
         return null;
     }
 
+    /**
+     * Creates a proxy {@link SCMSourceOwner} from an {@link Item} and a List of {@link SCMSource} instances. The caller
+     * is responsible for setting the owner.
+     *
+     * <p>In certain circumstances you may need to use a {@link SCMSource} from a concrete {@link Item} that cannot
+     * implement {@link  SCMSourceOwner}. For example, if you were having a {@link JobProperty} that retrieves things
+     * from a {@link SCMSource} you cannot make {@link FreeStyleProject} implement {@link SCMSource} yet you need to
+     * provide the {@link SCMSource} with access to its {@link SCMSourceOwner}.
+     *
+     * <p><strong>Only use this method if you absolutely cannot make the owning item a {@link SCMSourceOwner}</strong>.
+     *
+     * @param item the {@link Item} that owns the sources.
+     * @param proxyGetter a function that can retrieve the current proxy owner from a specified item. For example if
+     *         the proxy is created by a {@link JobProperty} the function would look up the property and return the
+     *         value of the (transient) field in the property that holds the proxy. If you do not need {@link SCMEvent}
+     *         support, then {@code null} will create a single-shot proxy owner. In the event that you provide a getter,
+     *         the returned proxy will implement {@link AutoCloseable} which callers can use to eagerly release the
+     *         proxy owner if it is no longer required.
+     * @param sourcesSupplier a {@link Supplier} that returns the current owned sources. The returned list will be
+     *         defensively copied before each use.
+     * @param criteriaSupplier the criteria that is applied to the sources.
+     * @return the proxy {@link SCMSourceOwner} instance.
+     */
+    static SCMSourceOwner proxyFromItem(@NonNull Item item,
+                                        @CheckForNull Function<Item, SCMSourceOwner> proxyGetter,
+                                        @NonNull Supplier<List<SCMSource>> sourcesSupplier,
+                                        @CheckForNull Supplier<SCMSourceCriteria> criteriaSupplier) {
+        Objects.requireNonNull(item);
+        Objects.requireNonNull(sourcesSupplier);
+        Set<Class<?>> interfaces = new LinkedHashSet<>();
+        interfaces.add(SCMSourceOwner.class);
+        // marker interface to allow us to track
+        interfaces.add(ProxyEnumerator.SCMProxySourceOwner.class);
+        // important item related interfaces
+        for (Class<?> interfaze : ProxyEnumerator.ITEM_CLASSES) {
+            if (interfaze.isInstance(item)) {
+                interfaces.add(interfaze);
+            }
+        }
+        ProxyEnumerator enumerator;
+        if (proxyGetter != null) {
+            // marker interface to allow early release
+            interfaces.add(AutoCloseable.class);
+            // interfaces related to SCMEvent handling
+            enumerator = ExtensionList.lookup(SCMSourceOwners.Enumerator.class).get(ProxyEnumerator.class);
+            for (Class<?> interfaze : ProxyEnumerator.EVENT_CLASSES) {
+                if (interfaze.isInstance(item)) {
+                    interfaces.add(interfaze);
+                }
+            }
+        } else {
+            enumerator = null;
+        }
+        ProxyEnumerator.SCMProxySourceOwner owner = (ProxyEnumerator.SCMProxySourceOwner) Proxy.newProxyInstance(
+                SCMSourceOwner.class.getClassLoader(),
+                interfaces.toArray(new Class[0]),
+                (proxy, method, args) -> {
+                    if (method.getDeclaringClass() == SCMSourceOwner.class) {
+                        switch (method.getName()) {
+                            case "getSCMSources":
+                                return Collections.unmodifiableList(new ArrayList<>(Util.fixNull(sourcesSupplier.get())));
+                            case "getSCMSource":
+                                return args[0] == null
+                                        ? null
+                                        : sourcesSupplier.get().stream()
+                                                .filter(s -> Objects.equals(args[0], s.getId()))
+                                                .findFirst()
+                                                .orElse(null);
+                            case "onSCMSourceUpdated":
+                                // no-op. We could have exposed a callback, but we want to discourage this old
+                                // method so instead we just treat it as a no-op.
+                                return null;
+                            case "getSCMSourceCriteria":
+                                return criteriaSupplier == null ? null : criteriaSupplier.get();
+                            default:
+                                throw new UnsupportedOperationException("Unsupported method: " + method.getName());
+                        }
+                    } else if (method.getDeclaringClass() == ProxyEnumerator.SCMProxySourceOwner.class) {
+                        switch (method.getName()) {
+                            case "__proxySourceOwner__isAttached":
+                                return proxyGetter != null && proxyGetter.apply(item) == proxy;
+                            case "__proxySourceOwner__getItem":
+                                return item;
+                            case "__proxySourceOwner__getItemGroup":
+                                return item instanceof ItemGroup ? item : null;
+                            default:
+                                throw new UnsupportedOperationException("Unsupported method: " + method.getName());
+                        }
+                    } else if (method.getDeclaringClass() == AutoCloseable.class) {
+                        if (enumerator != null) {
+                            enumerator.deregister(item, (ProxyEnumerator.SCMProxySourceOwner) proxy);
+                        }
+                        return null;
+                    } else {
+                        return method.invoke(item, args);
+                    }
+                });
+        if (enumerator != null) {
+            enumerator.register(item, owner);
+        }
+        return owner;
+    }
+
+    /**
+     * Allow the proxy owners to be retrieved.
+     */
+    @Restricted(NoExternalUse.class)
+    @Extension
+    class ProxyEnumerator extends SCMSourceOwners.Enumerator {
+
+        /**
+         * Classes that we should expose in case of instanceof checks.
+         */
+        static final Class[] ITEM_CLASSES = {
+                TopLevelItem.class,
+                Describable.class,
+                ItemGroup.class,
+                };
+        /**
+         * Classes that we should expose in case of instanceof checks if the proxy is registered for events.
+         */
+        static final Class[] EVENT_CLASSES = {
+                BuildableItemWithBuildWrappers.class,
+                BuildableItem.class,
+                Queue.Task.class,
+                };
+        /**
+         * The map of proxy instances keyed by owning item.
+         */
+        @GuardedBy("proxies")
+        private final Map<Item, List<SCMProxySourceOwner>> proxies = new WeakHashMap<>();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        @NonNull
+        public Iterator<SCMSourceOwner> iterator() {
+            final Jenkins jenkins = Jenkins.get();
+            return new Iterator<SCMSourceOwner>() {
+                final Iterator<Map.Entry<Item, List<SCMProxySourceOwner>>> entryIterator =
+                        proxies.entrySet().iterator();
+                Iterator<SCMProxySourceOwner> ownerIterator = null;
+                SCMProxySourceOwner next;
+
+                @Override
+                public boolean hasNext() {
+                    if (next != null) {
+                        return true;
+                    }
+                    while (ownerIterator != null && ownerIterator.hasNext()) {
+                        next = ownerIterator.next();
+                        if (next.__proxySourceOwner__isAttached()) {
+                            return true;
+                        }
+                    }
+                    ITEMS:
+                    while (entryIterator.hasNext()) {
+                        Map.Entry<Item, List<SCMProxySourceOwner>> entry = entryIterator.next();
+                        if (!entry.getValue().isEmpty()) {
+                            // we only return it if it is still present
+                            Item probe = entry.getKey();
+                            ItemGroup<? extends Item> parent;
+                            do {
+                                parent = probe.getParent();
+                                if (parent == null) {
+                                    // all parents have to be rooted at Jenkins
+                                    continue ITEMS;
+                                }
+                                if (parent.getItem(probe.getName()) != probe) {
+                                    // this will also skip items we are not allowed to access because of ACLs
+                                    // but we want that behaviour... and anyway most callers should be ACL.SYSTEM
+                                    continue ITEMS;
+                                }
+                                if (parent instanceof Item) {
+                                    probe = (Item) parent;
+                                } else if (!(parent instanceof Jenkins)) {
+                                    // all parents have to be rooted at Jenkins
+                                    continue ITEMS;
+                                }
+                            } while (jenkins != parent);
+                            // the path to this item is still valid
+                            ownerIterator = entry.getValue().iterator();
+                            while (ownerIterator != null && ownerIterator.hasNext()) {
+                                next = ownerIterator.next();
+                                if (next.__proxySourceOwner__isAttached()) {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                @Override
+                public SCMSourceOwner next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    try {
+                        return next;
+                    } finally {
+                        next = null;
+                    }
+                }
+            };
+        }
+
+        void register(Item item, SCMProxySourceOwner owner) {
+            synchronized (proxies) {
+                final List<SCMProxySourceOwner> owners =
+                        proxies.computeIfAbsent(item, (x) -> new ArrayList<>());
+                // most common reason for adding is to replace a prior one
+                owners.removeIf(s -> !s.__proxySourceOwner__isAttached());
+                owners.add(owner);
+            }
+        }
+
+        void deregister(Item item, SCMProxySourceOwner owner) {
+            synchronized (proxies) {
+                final List<SCMProxySourceOwner> sourceOwners = proxies.get(item);
+                if (sourceOwners != null) {
+                    sourceOwners.remove(owner);
+                    sourceOwners.removeIf(s -> !s.__proxySourceOwner__isAttached());
+                    if (sourceOwners.isEmpty()) {
+                        proxies.remove(item);
+                    }
+                }
+            }
+        }
+
+        void deregister(Item item) {
+            synchronized (proxies) {
+                proxies.remove(item);
+            }
+        }
+
+        void refresh(Item item) {
+            synchronized (proxies) {
+                final List<SCMProxySourceOwner> sourceOwners = proxies.get(item);
+                if (sourceOwners != null) {
+                    sourceOwners.removeIf(s -> !s.__proxySourceOwner__isAttached());
+                    if (sourceOwners.isEmpty()) {
+                        proxies.remove(item);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Marker interface that allows us access to detect if this is a proxy.
+         */
+        @Restricted(NoExternalUse.class)
+        protected interface SCMProxySourceOwner extends SCMSourceOwner, AutoCloseable {
+            /**
+             * Checks if the prxoy owner is still attached to the item.
+             *
+             * @return {@code true} if the proxy owner instance is still attached to the item through it's creator.
+             */
+            boolean __proxySourceOwner__isAttached();
+
+            /**
+             * Gets the backing owning item instance.
+             *
+             * @return the backing owning item instance.
+             */
+            Item __proxySourceOwner__getItem();
+
+            /**
+             * Gets the backing owning item instance as an {@link ItemGroup} (if it is one).
+             *
+             * @return the backing owning item instance as an {@link ItemGroup} (if it is one).
+             */
+            ItemGroup __proxySourceOwner__getItemGroup();
+        }
+    }
+
+    /**
+     * Listens for {@link Item} instances being removed to proactively empty the {@link ProxyEnumerator#proxies}.
+     */
+    @Restricted(NoExternalUse.class)
+    @Extension
+    class ProxyItemListener extends ItemListener {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onDeleted(Item item) {
+            final ProxyEnumerator enumerator =
+                    ExtensionList.lookup(SCMSourceOwners.Enumerator.class).get(ProxyEnumerator.class);
+            if (enumerator != null) {
+                enumerator.deregister(item);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onUpdated(Item item) {
+            final ProxyEnumerator enumerator =
+                    ExtensionList.lookup(SCMSourceOwners.Enumerator.class).get(ProxyEnumerator.class);
+            if (enumerator != null) {
+                enumerator.refresh(item);
+            }
+        }
+    }
+
+    /**
+     * Exposes credentials correctly from the proxy.
+     */
+    @Restricted(NoExternalUse.class)
+    @Extension
+    class ProxyCredentialsProvider extends CredentialsProvider {
+        @Override
+        public boolean isEnabled(Object context) {
+            return context instanceof ProxyEnumerator.SCMProxySourceOwner;
+        }
+
+        private Item ctx(ProxyEnumerator.SCMProxySourceOwner context) {
+            return context.__proxySourceOwner__getItem();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(
+                @NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup,
+                @Nullable Authentication authentication) {
+            return getCredentials(
+                    type,
+                    itemGroup,
+                    authentication,
+                    Collections.emptyList()
+            );
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(
+                @NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup,
+                @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements) {
+            if (itemGroup instanceof ProxyEnumerator.SCMProxySourceOwner) {
+                return lookupCredentials(
+                        type,
+                        ((ProxyEnumerator.SCMProxySourceOwner) itemGroup).__proxySourceOwner__getItemGroup(),
+                        authentication,
+                        domainRequirements
+                );
+            }
+            return Collections.emptyList();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends IdCredentials> ListBoxModel getCredentialIds(
+                @NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup,
+                @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements,
+                @NonNull CredentialsMatcher matcher) {
+            if (itemGroup instanceof ProxyEnumerator.SCMProxySourceOwner) {
+                return listCredentials(
+                        type,
+                        ((ProxyEnumerator.SCMProxySourceOwner) itemGroup).__proxySourceOwner__getItemGroup(),
+                        authentication,
+                        domainRequirements,
+                        matcher
+                );
+            }
+            return new ListBoxModel();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(
+                @NonNull Class<C> type,
+                @NonNull Item item,
+                @Nullable Authentication authentication) {
+            return getCredentials(
+                    type,
+                    item,
+                    authentication,
+                    Collections.emptyList()
+            );
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(
+                @NonNull Class<C> type,
+                @NonNull Item item,
+                @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements) {
+            if (item instanceof ProxyEnumerator.SCMProxySourceOwner) {
+                return lookupCredentials(
+                        type,
+                        ((ProxyEnumerator.SCMProxySourceOwner) item).__proxySourceOwner__getItem(),
+                        authentication,
+                        domainRequirements);
+            }
+            return Collections.emptyList();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends IdCredentials> ListBoxModel getCredentialIds(
+                @NonNull Class<C> type,
+                @NonNull Item item,
+                @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements,
+                @NonNull CredentialsMatcher matcher) {
+            if (item instanceof ProxyEnumerator.SCMProxySourceOwner) {
+                return listCredentials(
+                        type,
+                        ((ProxyEnumerator.SCMProxySourceOwner) item).__proxySourceOwner__getItem(),
+                        authentication,
+                        domainRequirements,
+                        matcher);
+            }
+            return new ListBoxModel();
+        }
+    }
 }

--- a/src/test/java/jenkins/scm/api/SCMSourceOwnerTest.java
+++ b/src/test/java/jenkins/scm/api/SCMSourceOwnerTest.java
@@ -1,0 +1,286 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.scm.api;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Util;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.util.ListBoxModel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import jenkins.scm.impl.NullSCMSource;
+import org.acegisecurity.Authentication;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SCMSourceOwnerTest {
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void given__proxy__when__getSCMSources__then__returned() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        List<SCMSource> sources = new ArrayList<>(Collections.singletonList(new NullSCMSource()));
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        try {
+            assertThat(owner.getSCMSources(), is(sources));
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    public void given__proxy__when__getSCMSource__then__returned() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        try {
+            assertThat(owner.getSCMSource(source.getId()), is(source));
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void given__proxy__when__onSCMSourceUpdated__then__doesnt_throw_unsupported() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        try {
+            // just want to be sure this method doesn't cause unsupported operation
+            owner.onSCMSourceUpdated(source);
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    public void given__proxy__when__getSCMSourceCriteria__then__returned() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        final SCMSourceCriteria criteria = (SCMSourceCriteria) (probe, listener) -> false;
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, () -> criteria);
+        try {
+            assertThat(owner.getSCMSourceCriteria(source), is(criteria));
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    public void given__proxy__when__getName__then__returned() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        try {
+            assertThat(owner.getName(), is(item.getName()));
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    public void given__proxy__when__getParent__then__returned() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        try {
+            assertThat(owner.getParent(), is(item.getParent()));
+        } finally {
+            if (owner instanceof AutoCloseable) ((AutoCloseable) owner).close();
+        }
+    }
+
+    @Test
+    public void given__attached_proxy__when__searching_for_all__then__found() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        Map<Item,SCMSourceOwner> ownerMap = new HashMap<>();
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, ownerMap::get, () -> sources, null);
+        ownerMap.put(item, owner);
+        assertThat(StreamSupport.stream(SCMSourceOwners.all().spliterator(), false).anyMatch(s -> s == owner), is(true));
+    }
+
+    @Test
+    public void given__single_shot_proxy__when__searching_for_all__then__not_found() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+        assertThat(StreamSupport.stream(SCMSourceOwners.all().spliterator(), false).anyMatch(s -> s == owner), is(false));
+    }
+
+    @Test
+    public void given__item_with_own_credentials_store__when__listing_credentials_from_proxy__then__credentials_found() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final UsernamePasswordCredentialsImpl credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "foo", "probe", "bob", "secret");
+        item.addProperty(new CredentialJobProperty(Collections.singletonList(credentials)));
+        ListBoxModel options = CredentialsProvider.listCredentials(
+                IdCredentials.class,
+                item,
+                null,
+                Collections.emptyList(),
+                CredentialsMatchers.withId("foo"));
+        // i'd use assumeThat but this is a critical test case
+        assertThat("Test setup item scoped credentials correctly", options, hasSize(1));
+        assertThat("Test setup item scoped credentials correctly", options.get(0).value, is("foo"));
+
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+
+        options = CredentialsProvider.listCredentials(
+                IdCredentials.class,
+                owner,
+                null,
+                Collections.emptyList(),
+                CredentialsMatchers.withId("foo"));
+        assertThat("We have correctly proxyed item scoped credentials", options, hasSize(1));
+        assertThat("We have correctly proxyed item scoped credentials", options.get(0).value, is("foo"));
+    }
+
+    @Test
+    public void given__item_with_own_credentials_store__when__retrieving_credentials_from_proxy__then__credentials_found() throws Exception {
+        final FreeStyleProject item = r.createFreeStyleProject();
+        final UsernamePasswordCredentialsImpl credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "foo", "probe", "bob", "secret");
+        item.addProperty(new CredentialJobProperty(Collections.singletonList(credentials)));
+        List<IdCredentials> list = CredentialsProvider.lookupCredentials(
+                IdCredentials.class,
+                item,
+                null,
+                Collections.emptyList());
+        // i'd use assumeThat but this is a critical test case
+        assertThat("Test setup item scoped credentials correctly", list, hasItem(credentials));
+
+        final NullSCMSource source = new NullSCMSource();
+        List<SCMSource> sources = Collections.singletonList(source);
+        SCMSourceOwner owner = SCMSourceOwner.proxyFromItem(item, null, () -> sources, null);
+
+        list = CredentialsProvider.lookupCredentials(
+                IdCredentials.class,
+                owner,
+                null,
+                Collections.emptyList());
+        assertThat("We have correctly proxyed item scoped credentials", list, hasItem(credentials));
+    }
+
+    public static class CredentialJobProperty extends JobProperty<FreeStyleProject> {
+        private final List<Credentials> credentials;
+
+        @DataBoundConstructor
+        public CredentialJobProperty(List<Credentials> credentials) {
+            this.credentials = new ArrayList<>(Util.fixNull(credentials));
+        }
+
+        public List<Credentials> getCredentials() {
+            return Collections.unmodifiableList(credentials);
+        }
+
+        @TestExtension
+        public static class CredentialsJobPropertyDescriptor extends JobPropertyDescriptor {
+        }
+    }
+
+    /**
+     * Avoiding a dependency on folders plugin while also giving a bonus of testing in the event some crazy person
+     * adds credentials directly to items.
+     */
+    @TestExtension
+    public static class JobCredentialsProvider extends CredentialsProvider {
+
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                              @Nullable Authentication authentication) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isEnabled(Object context) {
+            return context instanceof FreeStyleProject
+                    && ((FreeStyleProject)context).getProperty(CredentialJobProperty.class) != null;
+        }
+
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @NonNull Item item,
+                                                              @Nullable Authentication authentication) {
+            return getCredentials(type, item, authentication, Collections.emptyList());
+        }
+
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @NonNull Item item,
+                                                              @Nullable Authentication authentication,
+                                                              @NonNull List<DomainRequirement> domainRequirements) {
+            if (item instanceof FreeStyleProject) {
+                CredentialJobProperty jobProperty = ((FreeStyleProject) item).getProperty(CredentialJobProperty.class);
+                if (jobProperty != null) {
+                    return jobProperty.credentials.stream()
+                            .filter(type::isInstance)
+                            .map(type::cast)
+                            .collect(Collectors.toList());
+                }
+
+            }
+            return Collections.emptyList();
+        }
+    }
+
+}


### PR DESCRIPTION
Alternative approach to [JENKINS-43802](https://issues.jenkins-ci.org/browse/JENKINS-43802).

As I see it, there are multiple potential valid use cases for reusing `SCMSource` in a context where we cannot convert the owning `Item` into a `SCMSourceOwner`. As such we should provide a mechanism to adapt an `Item` into a `SCMSourceOwner`.

There are some implications to this:

* We need consumers of this new API to decide whether they want their sources discoverable by the event system or not. For example [JENKINS-41497](https://issues.jenkins-ci.org/browse/JENKINS-41497) indicates that a significant number of users probably do not want implicit triggering of all jobs using a shared library when the shared library is changed.

* We need to specifically support credentials lookup on the proxy, which means adding a dependency to the credentials plugin. The user documentation already guides implementers to use the credentials plugin, so that shouldn't be an issue.