### PR TITLE
[JENKINS-60050] Improve interface ChangeRequestSCMHead

### DIFF
--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequest.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequest.java
@@ -1,0 +1,20 @@
+package jenkins.scm.api.mixin;
+
+import org.kohsuke.stapler.export.Exported;
+
+import javax.annotation.Nonnull;
+
+/**
+ * The interface carry with the information of a change request,
+ *  such as pull request or merge request.
+ * @since TODO
+ */
+public interface ChangeRequest {
+    /**
+     * Returns the title of the change request
+     * @return title of the change request
+     */
+    @Exported
+    @Nonnull
+    String getTitle();
+}

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -30,6 +30,8 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Mixin interface to identify {@link SCMHead} instances that correspond to a change request.
  *
@@ -53,7 +55,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * @return the {@link ChangeRequestCheckoutStrategy}.
      * @since TODO
      */
-    @NonNull
+    @CheckForNull
     default ChangeRequestCheckoutStrategy getCheckoutStrategy() {
         return null;
     }
@@ -71,7 +73,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      *
      * @since TODO
      */
-    @NonNull
+    @CheckForNull
     @Exported
     default String getOriginName() {
         return null;
@@ -85,14 +87,4 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
     @Exported
     @NonNull
     SCMHead getTarget();
-
-    /**
-     * Returns the title of the change request
-     * @return title of the change request
-     */
-    @Exported
-    @NonNull
-    default String getTitle() {
-        return null;
-    }
 }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -68,6 +68,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * against the {@link #getOrigin()} directly and the change request were be discoverable as a regular
      * {@link SCMHead} or {@link #getName()} if such a concept is not possible in the backing source control system.
      */
+    @CheckForNull
     default String getOriginName() {
         return null;
     }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -68,6 +68,8 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * @return the name this {@link ChangeRequestSCMHead} would have if the {@link SCMSource} were configured
      * against the {@link #getOrigin()} directly and the change request were be discoverable as a regular
      * {@link SCMHead} or {@link #getName()} if such a concept is not possible in the backing source control system.
+     *
+     * @since TODO
      */
     @CheckForNull
     default String getOriginName() {

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -52,6 +52,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      *
      * @return the {@link ChangeRequestCheckoutStrategy}.
      */
+    @CheckForNull
     default ChangeRequestCheckoutStrategy getCheckoutStrategy() {
         return null;
     }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -30,8 +30,6 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import org.kohsuke.stapler.export.Exported;
 
-import javax.annotation.CheckForNull;
-
 /**
  * Mixin interface to identify {@link SCMHead} instances that correspond to a change request.
  *
@@ -55,7 +53,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * @return the {@link ChangeRequestCheckoutStrategy}.
      * @since TODO
      */
-    @CheckForNull
+    @NonNull
     default ChangeRequestCheckoutStrategy getCheckoutStrategy() {
         return null;
     }
@@ -73,7 +71,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      *
      * @since TODO
      */
-    @CheckForNull
+    @NonNull
     @Exported
     default String getOriginName() {
         return null;
@@ -93,7 +91,8 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * @return title of the change request
      */
     @Exported
+    @NonNull
     default String getTitle() {
-        return "";
+        return null;
     }
 }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -48,6 +48,30 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
     String getId();
 
     /**
+     * Returns the {@link ChangeRequestCheckoutStrategy} of this {@link ChangeRequestSCMHead}.
+     *
+     * @return the {@link ChangeRequestCheckoutStrategy}.
+     */
+    default ChangeRequestCheckoutStrategy getCheckoutStrategy() {
+        return null;
+    }
+
+    /**
+     * Returns the name of the actual head on the source control system which may or may not be different from
+     * {@link #getName()}. For example in GitHub or Bitbucket this method would return the name of the origin branch
+     * whereas {@link #getName()} would return something like {@code PR-24}. It is perfectly acceptable for a SCM
+     * implementation to return the same value as {@link #getName()} where the SCM implementation does not have a
+     * separate concept of origin name.
+     *
+     * @return the name this {@link ChangeRequestSCMHead} would have if the {@link SCMSource} were configured
+     * against the {@link #getOrigin()} directly and the change request were be discoverable as a regular
+     * {@link SCMHead} or {@link #getName()} if such a concept is not possible in the backing source control system.
+     */
+    default String getOriginName() {
+        return null;
+    }
+
+    /**
      * Branch to which this change would be merged or applied if it were accepted.
      *
      * @return a "target" or "base" branch
@@ -56,4 +80,11 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
     @NonNull
     SCMHead getTarget();
 
+    /**
+     * Returns the title of the change request
+     * @return title of the change request
+     */
+    default String getTitle() {
+        return "";
+    }
 }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -51,6 +51,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * Returns the {@link ChangeRequestCheckoutStrategy} of this {@link ChangeRequestSCMHead}.
      *
      * @return the {@link ChangeRequestCheckoutStrategy}.
+     * @since TODO
      */
     @CheckForNull
     default ChangeRequestCheckoutStrategy getCheckoutStrategy() {

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead.java
@@ -30,6 +30,8 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Mixin interface to identify {@link SCMHead} instances that correspond to a change request.
  *
@@ -72,6 +74,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * @since TODO
      */
     @CheckForNull
+    @Exported
     default String getOriginName() {
         return null;
     }
@@ -89,6 +92,7 @@ public interface ChangeRequestSCMHead extends SCMHeadMixin {
      * Returns the title of the change request
      * @return title of the change request
      */
+    @Exported
     default String getTitle() {
         return "";
     }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead2.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead2.java
@@ -24,37 +24,16 @@
 
 package jenkins.scm.api.mixin;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.SCMSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Additional attributes of a {@link ChangeRequestSCMHead} that should have been in the original mixin but we are not
  * targeting Java 8 so we cannot add the default methods to the interface and must have an ugly {@code 2} class instead.
  * @since 2.2.0
  */
-// TODO once Java 8 is baseline move method to ChangeRequestSCMHead with default return value,
-// TODO deprecate this interface and add @Restricted(NoExternalUse.class) (retain empty interface for binary compat)
+@Deprecated
+@Restricted(NoExternalUse.class)
 public interface ChangeRequestSCMHead2 extends ChangeRequestSCMHead {
-    /**
-     * Returns the {@link ChangeRequestCheckoutStrategy} of this {@link ChangeRequestSCMHead}.
-     *
-     * @return the {@link ChangeRequestCheckoutStrategy}.
-     */
-    @NonNull
-    ChangeRequestCheckoutStrategy getCheckoutStrategy();
-
-    /**
-     * Returns the name of the actual head on the source control system which may or may not be different from
-     * {@link #getName()}. For example in GitHub or Bitbucket this method would return the name of the origin branch
-     * whereas {@link #getName()} would return something like {@code PR-24}. It is perfectly acceptable for a SCM
-     * implementation to return the same value as {@link #getName()} where the SCM implementation does not have a
-     * separate concept of origin name.
-     *
-     * @return the name this {@link ChangeRequestSCMHead} would have if the {@link SCMSource} were configured
-     * against the {@link #getOrigin()} directly and the change request were be discoverable as a regular
-     * {@link SCMHead} or {@link #getName()} if such a concept is not possible in the backing source control system.
-     */
-    @NonNull
-    String getOriginName();
+    //retain empty interface for binary compatible
 }

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead2.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMHead2.java
@@ -30,7 +30,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Additional attributes of a {@link ChangeRequestSCMHead} that should have been in the original mixin but we are not
  * targeting Java 8 so we cannot add the default methods to the interface and must have an ugly {@code 2} class instead.
- * @since 2.2.0
+  * @since TODO
+  * @deprecated use {@link ChangeRequestSCMHead} instead. 
  */
 @Deprecated
 @Restricted(NoExternalUse.class)

--- a/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMRevision.java
+++ b/src/main/java/jenkins/scm/api/mixin/ChangeRequestSCMRevision.java
@@ -71,13 +71,13 @@ public abstract class ChangeRequestSCMRevision<H extends SCMHead & ChangeRequest
      *
      * @return {@code true} if the effective revision is the result of merging onto the {@link #getTarget()}
      * revision {@code false} if the effective revision ignores the {@link #getTarget()}.
-     * @see ChangeRequestSCMHead2
+     * @see ChangeRequestSCMHead
      */
     @Exported
     public final boolean isMerge() {
         SCMHead head = getHead();
-        return !(head instanceof ChangeRequestSCMHead2)
-                || ((ChangeRequestSCMHead2) head).getCheckoutStrategy() != ChangeRequestCheckoutStrategy.HEAD;
+        return !(head instanceof ChangeRequestSCMHead)
+                || ((ChangeRequestSCMHead) head).getCheckoutStrategy() != ChangeRequestCheckoutStrategy.HEAD;
     }
 
     /**

--- a/src/main/java/jenkins/scm/api/trait/SCMSourceRequest.java
+++ b/src/main/java/jenkins/scm/api/trait/SCMSourceRequest.java
@@ -44,7 +44,7 @@ import jenkins.scm.api.SCMProbe;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.SCMHeadMixin;
 
 /**
@@ -465,14 +465,14 @@ public abstract class SCMSourceRequest implements Closeable {
      * A lambda that produces an intermediate summary used to drive creation of the {@link SCMSourceCriteria.Probe}
      * and {@link SCMRevision} instances.
      * <p>
-     * Some {@link SCMRevision} instances may be expensive to instantiate, for example a {@link ChangeRequestSCMHead2}
+     * Some {@link SCMRevision} instances may be expensive to instantiate, for example a {@link ChangeRequestSCMHead}
      * may need to get the effective merge revision in order to comply with the equality and "offline" requirement
      * of a {@link SCMRevision} which could require either asking the remote server or performing a local trial merge.
      * As this type of operation is only required if the {@link SCMHead} actually meets the {@link SCMSourceCriteria}
      * it may be preferred to delay instantiation of the {@link SCMRevision} and instead create the
      * {@link SCMSourceCriteria.Probe} from some intermediate. For example the {@link SCMSourceCriteria} may
-     * only be checking the existence of files, if the file is present in both the {@link ChangeRequestSCMHead2}
-     * and its {@link ChangeRequestSCMHead2#getTarget()} then it will also be present in the merge revision and hence
+     * only be checking the existence of files, if the file is present in both the {@link ChangeRequestSCMHead}
+     * and its {@link ChangeRequestSCMHead#getTarget()} then it will also be present in the merge revision and hence
      * the computation of the merge revision can be avoided completely.
      *
      * @param <I> the type of intermediate value or {@link Void} if no intermediate is required.

--- a/src/test/java/jenkins/scm/impl/mock/MockChangeRequestSCMHead.java
+++ b/src/test/java/jenkins/scm/impl/mock/MockChangeRequestSCMHead.java
@@ -29,9 +29,9 @@ import java.util.Locale;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 
-public class MockChangeRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
+public class MockChangeRequestSCMHead extends SCMHead implements ChangeRequestSCMHead {
     private final String target;
     private final Integer number;
     private final SCMHeadOrigin origin;


### PR DESCRIPTION
The baseline already is java8. So I made this change. Plus, I put the method `getTitle` into the original interface. Because of PR's title is quite important information. Please do not hesitate to leave you thinking about my changes.