### PR TITLE
[JENKINS-48431] Support both lightweight checkout AND build parameters

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -568,7 +568,7 @@ public abstract class SCMFileSystem implements Closeable {
          * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
          */
         @CheckForNull
-        public abstract SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return build(build.getParent(), scm, rev);
         }

--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -169,7 +169,7 @@ public abstract class SCMFileSystem implements Closeable {
      * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
      */
     @CheckForNull
-    public static SCMFileSystem of(@NonNull Run build, @NonNull SCM scm) throws IOException, InterruptedException {
+    public static SCMFileSystem of(@NonNull Run<?, ?> build, @NonNull SCM scm) throws IOException, InterruptedException {
         return of(build, scm, null);
     }
 
@@ -186,7 +186,7 @@ public abstract class SCMFileSystem implements Closeable {
      * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
      */
     @CheckForNull
-    public static SCMFileSystem of(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+    public static SCMFileSystem of(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
             throws IOException, InterruptedException {
         Objects.requireNonNull(scm);
         SCMFileSystem fallBack = null;
@@ -568,8 +568,10 @@ public abstract class SCMFileSystem implements Closeable {
          * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
          */
         @CheckForNull
-        public abstract SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
-                throws IOException, InterruptedException;
+        public abstract SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return build(build.getParent(), scm, rev);
+        }
 
         /**
          * Given a {@link SCM} this should try to build a corresponding {@link SCMFileSystem} instance that

--- a/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
+++ b/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
@@ -120,7 +120,7 @@ public class SCMFileSystemTest {
 
         @Override
         @CheckForNull
-        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return null;
         }
@@ -158,7 +158,7 @@ public class SCMFileSystemTest {
 
         @Override
         @CheckForNull
-        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return null;
         }

--- a/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
+++ b/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
@@ -27,6 +27,7 @@ package jenkins.scm.impl;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Item;
+import hudson.model.Run;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import jenkins.scm.api.SCMFileSystem;
@@ -117,6 +118,13 @@ public class SCMFileSystemTest {
             return null;
         }
 
+        @Override
+        @CheckForNull
+        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return null;
+        }
+
     }
 
     @TestExtension("filesystem_supports_false_implementation_for_descriptor")
@@ -144,6 +152,13 @@ public class SCMFileSystemTest {
         @Override
         @CheckForNull
         public SCMFileSystem build(@NonNull Item owner, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return null;
+        }
+
+        @Override
+        @CheckForNull
+        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return null;
         }


### PR DESCRIPTION
[JENKINS-48431](https://issues.jenkins-ci.org/browse/JENKINS-48431) To support both lightweight checkout AND build parameters, we need to:

- recover the environment parameters of the build
- evaluate the SCM structure according to the build environment parameters

This leads to implement a new method :
```
public static SCMFileSystem of(@nonnull Run build, @nonnull SCM scm, @checkfornull SCMRevision rev)
```

This new method offer the capacity to recover the environments parameter of the build as the current build is propagated through the new method.

Note that this modification is in relation with two other pull requests that concerns:
- workflow-cps-plugin: https://github.com/jenkinsci/workflow-cps-plugin/pull/329
- git-plugin: https://github.com/jenkinsci/git-plugin/pull/772