### PR TITLE
Custom Avatar sources for AvatarCache

### DIFF
--- a/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
@@ -37,13 +37,9 @@ import hudson.util.NamingThreadFactory;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -65,7 +61,8 @@ import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.IOUtils;
+import jenkins.scm.impl.avatars.AvatarCacheSource.AvatarImage;
+
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -88,6 +85,11 @@ public class AvatarCache implements UnprotectedRootAction {
      * Our logger.
      */
     private static final Logger LOGGER = Logger.getLogger(AvatarCache.class.getName());
+    /**
+     * URI For this action
+     */
+    private static final String ActionURI = "avatar-cache";
+
     /**
      * Maximum concurrent requests to fetch images.
      */
@@ -134,14 +136,26 @@ public class AvatarCache implements UnprotectedRootAction {
      * @throws IllegalStateException if called outside of a request handling thread.
      */
     public static String buildUrl(@NonNull String url, @NonNull String size) {
+        return buildUrl(new UrlAvatarCacheSource(url), size);
+    }
+
+    /**
+     * Builds the URL for the cached avatar image of the required size.
+     *
+     * @param source source avatar image definition.
+     * @param size   the size of the image.
+     * @return the URL of the cached image.
+     * @throws IllegalStateException if called outside of a request handling thread.
+     */
+    public static String buildUrl(@NonNull AvatarCacheSource source, @NonNull String size) {
         Jenkins j = Jenkins.get();
         AvatarCache instance = ExtensionList.lookup(RootAction.class).get(AvatarCache.class);
         if (instance == null) {
             throw new AssertionError();
         }
-        String key = Util.getDigestOf(AvatarCache.class.getName() + url);
+        String key = Util.getDigestOf(AvatarCache.class.getName() + source.hashKey());
         // seed the cache
-        instance.getCacheEntry(key, url);
+        instance.getCacheEntry(key, source);
         try {
             return j.getRootUrlFromRequest()
                     + instance.getUrlName()
@@ -288,7 +302,7 @@ public class AvatarCache implements UnprotectedRootAction {
      */
     @Override
     public String getUrlName() {
-        return "avatar-cache";
+        return ActionURI;
     }
 
     /**
@@ -326,7 +340,7 @@ public class AvatarCache implements UnprotectedRootAction {
         }
         final CacheEntry avatar = getCacheEntry(key, null);
         final long since = req.getDateHeader("If-Modified-Since");
-        if (avatar == null || !(avatar.url.startsWith("http://") || avatar.url.startsWith("https://"))) {
+        if (avatar == null || !avatar.canFetch()) {
             if (startedTime <= since) {
                 return new HttpResponse() {
                     @Override
@@ -341,17 +355,18 @@ public class AvatarCache implements UnprotectedRootAction {
             // we will generate avatars if the URL is not HTTP based
             // since the url string will not magically turn itself into a HTTP url this avatar is immutable
             return new ImageResponse(
-                    generateAvatar(avatar == null ? "" : avatar.url, targetSize),
+                    generateAvatar(avatar == null ? "" : avatar.source.hashKey(), targetSize),
                     true,
                     startedTime,
                     "max-age=365000000, immutable, public"
             );
         }
+
         if (avatar.pending() && avatar.image == null) {
             // serve a temporary avatar until we get the remote one, no caching as we could have the real deal
             // real soon now
             return new ImageResponse(
-                    generateAvatar(avatar.url, targetSize),
+                    generateAvatar(avatar.source.hashKey(), targetSize),
                     true,
                     -1L,
                     "no-cache, public"
@@ -368,10 +383,11 @@ public class AvatarCache implements UnprotectedRootAction {
                 }
             };
         }
+        // If no image, generate a temp avatar
         if (avatar.image == null) {
             // we can retry in an hour
             return new ImageResponse(
-                    generateAvatar(avatar.url, targetSize),
+                    generateAvatar(avatar.source.hashKey(), targetSize),
                     true,
                     -1L,
                     "max-age=3600, public"
@@ -395,16 +411,16 @@ public class AvatarCache implements UnprotectedRootAction {
      * @return the entry or {@code null} if a read-only check found no matching entry.
      */
     @Nullable
-    private CacheEntry getCacheEntry(@NonNull final String key, @Nullable final String url) {
+    private CacheEntry getCacheEntry(@NonNull final String key, @Nullable final AvatarCacheSource source) {
         CacheEntry entry = cache.get(key);
         if (entry == null) {
             synchronized (serviceLock) {
                 entry = cache.get(key);
                 if (entry == null) {
-                    if (url == null) {
+                    if (source == null) {
                         return null;
                     }
-                    entry = new CacheEntry(url, service.submit(new FetchImage(url)));
+                    entry = new CacheEntry(source, service.submit(new FetchImage(source)));
                     cache.put(key, entry);
                 }
             }
@@ -412,7 +428,7 @@ public class AvatarCache implements UnprotectedRootAction {
             if (entry.isStale()) {
                 synchronized (serviceLock) {
                     if (!entry.pending()) {
-                        entry.setFuture(service.submit(new FetchImage(entry.url)));
+                        entry.setFuture(service.submit(new FetchImage(entry.source)));
                     }
                 }
             }
@@ -445,9 +461,9 @@ public class AvatarCache implements UnprotectedRootAction {
      */
     private static class CacheEntry {
         /**
-         * The URL that is cached.
+         * Source for avatar
          */
-        private final String url;
+        private final AvatarCacheSource source;
         /**
          * The cached image or {@code null} if not retrieved yet.
          */
@@ -467,8 +483,8 @@ public class AvatarCache implements UnprotectedRootAction {
          */
         private Future<CacheEntry> future;
 
-        private CacheEntry(String url, BufferedImage image, long lastModified) {
-            this.url = url;
+        private CacheEntry(AvatarCacheSource source, BufferedImage image, long lastModified) {
+            this.source = source;
             if (image.getHeight() > 128 || image.getWidth() > 128) {
                 // limit the amount of storage
                 this.image = scaleImage(image, 128);
@@ -479,15 +495,22 @@ public class AvatarCache implements UnprotectedRootAction {
             this.lastModified = lastModified < 0 ? System.currentTimeMillis() : lastModified;
         }
 
-        private CacheEntry(String url, Future<CacheEntry> future) {
-            this.url = url;
+        /**
+         * Check if this entry is fetch-able
+         */
+        public boolean canFetch() {
+            return (source != null && source.canFetch());
+        }
+
+        private CacheEntry(AvatarCacheSource source, Future<CacheEntry> future) {
+            this.source = source;
             this.image = null;
             this.lastModified = System.currentTimeMillis();
             this.future = future;
         }
 
-        private CacheEntry(String url) {
-            this.url = url;
+        private CacheEntry(AvatarCacheSource source) {
+            this.source = source;
             this.lastModified = System.currentTimeMillis();
         }
 
@@ -580,10 +603,10 @@ public class AvatarCache implements UnprotectedRootAction {
      * A task to fetch an image from a remote URL.
      */
     private static class FetchImage implements Callable<CacheEntry> {
-        private final String url;
+        private final AvatarCacheSource source;
 
-        private FetchImage(String url) {
-            this.url = url;
+        private FetchImage(@NonNull AvatarCacheSource source) {
+            this.source = source;
         }
 
         /**
@@ -591,48 +614,12 @@ public class AvatarCache implements UnprotectedRootAction {
          */
         @Override
         public CacheEntry call() throws Exception {
-            LOGGER.log(Level.FINE, "Attempting to fetch remote avatar: {0}", url);
-            long start = System.nanoTime();
-            try {
-                if (!(url.startsWith("http://") || url.startsWith("https://"))) {
-                    return new CacheEntry(url);
-                }
-                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-                try {
-                    connection.setConnectTimeout(10000);
-                    connection.setReadTimeout(30000);
-                    if (!connection.getContentType().startsWith("image/")) {
-                        return new CacheEntry(this.url);
-                    }
-                    int length = connection.getContentLength();
-                    // buffered stream should be no more than 16k if we know the length
-                    // if we don't know the length then 8k is what we will use
-                    length = length > 0 ? Math.min(16384, length) : 8192;
-                    InputStream is = null;
-                    try {
-                        is = connection.getInputStream();
-                        BufferedInputStream bis = new BufferedInputStream(is, length);
-                        BufferedImage image = ImageIO.read(bis);
-                        if (image == null) {
-                            return new CacheEntry(this.url);
-                        }
-                        return new CacheEntry(this.url, image, connection.getLastModified());
-                    } finally {
-                        IOUtils.closeQuietly(is);
-                    }
-                } finally {
-                    connection.disconnect();
-                }
-            } catch (IOException e) {
-                LOGGER.log(Level.INFO, e.getMessage(), e);
-                return new CacheEntry(url);
-            } finally {
-                long end = System.nanoTime();
-                long duration = TimeUnit.NANOSECONDS.toMillis(end - start);
-                LOGGER.log(duration > 250 ? Level.INFO : Level.FINE, "Avatar lookup of {0} took {1}ms",
-                        new Object[]{url, duration}
-                );
+            AvatarImage image = source.fetch();
+            // If no image, return no image
+            if (image == null) {
+                return new CacheEntry(source);
             }
+            return new CacheEntry(source, image.image, image.lastModified);
         }
     }
 }

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
@@ -145,7 +145,7 @@ public class AvatarCache implements UnprotectedRootAction {
      * @return the URL of the cached image.
      * @throws IllegalStateException if called outside of a request handling thread.
      */
-    public static String buildUrl(@NonNull AvatarCacheSource source, @NonNull String size) {
+    public static String buildUrl(@NonNull AvatarImageSource source, @NonNull String size) {
         Jenkins j = Jenkins.get();
         AvatarCache instance = ExtensionList.lookup(RootAction.class).get(AvatarCache.class);
         if (instance == null) {
@@ -409,7 +409,7 @@ public class AvatarCache implements UnprotectedRootAction {
      * @return the entry or {@code null} if a read-only check found no matching entry.
      */
     @Nullable
-    private CacheEntry getCacheEntry(@NonNull final String key, @Nullable final AvatarCacheSource source) {
+    private CacheEntry getCacheEntry(@NonNull final String key, @Nullable final AvatarImageSource source) {
         CacheEntry entry = cache.get(key);
         if (entry == null) {
             synchronized (serviceLock) {
@@ -461,7 +461,7 @@ public class AvatarCache implements UnprotectedRootAction {
         /**
          * Source for avatar
          */
-        private final AvatarCacheSource source;
+        private final AvatarImageSource source;
         /**
          * The cached image or {@code null} if not retrieved yet.
          */
@@ -481,7 +481,7 @@ public class AvatarCache implements UnprotectedRootAction {
          */
         private Future<CacheEntry> future;
 
-        private CacheEntry(AvatarCacheSource source, BufferedImage image, long lastModified) {
+        private CacheEntry(AvatarImageSource source, BufferedImage image, long lastModified) {
             this.source = source;
             if (image.getHeight() > 128 || image.getWidth() > 128) {
                 // limit the amount of storage
@@ -500,14 +500,14 @@ public class AvatarCache implements UnprotectedRootAction {
             return (source != null && source.canFetch());
         }
 
-        private CacheEntry(AvatarCacheSource source, Future<CacheEntry> future) {
+        private CacheEntry(AvatarImageSource source, Future<CacheEntry> future) {
             this.source = source;
             this.image = null;
             this.lastModified = System.currentTimeMillis();
             this.future = future;
         }
 
-        private CacheEntry(AvatarCacheSource source) {
+        private CacheEntry(AvatarImageSource source) {
             this.source = source;
             this.lastModified = System.currentTimeMillis();
         }
@@ -601,9 +601,9 @@ public class AvatarCache implements UnprotectedRootAction {
      * A task to fetch an image from a remote URL.
      */
     private static class FetchImage implements Callable<CacheEntry> {
-        private final AvatarCacheSource source;
+        private final AvatarImageSource source;
 
-        private FetchImage(@NonNull AvatarCacheSource source) {
+        private FetchImage(@NonNull AvatarImageSource source) {
             this.source = source;
         }
 

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
@@ -405,7 +405,7 @@ public class AvatarCache implements UnprotectedRootAction {
      * Retrieves the entry from the cache.
      *
      * @param key the cache key.
-     * @param url the URL to fetch if the entry is missing or {@code null} to perform a read-only check.
+     * @param source the URL to fetch if the entry is missing or {@code null} to perform a read-only check.
      * @return the entry or {@code null} if a read-only check found no matching entry.
      */
     @Nullable
@@ -477,7 +477,7 @@ public class AvatarCache implements UnprotectedRootAction {
          */
         private long lastAccessed = -1L;
         /**
-         * The queued request to retrieve the image from the {@link #url}.
+         * The queued request to retrieve the image from the {@link #source}.
          */
         private Future<CacheEntry> future;
 

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarCache.java
@@ -55,13 +55,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
-import jenkins.scm.impl.avatars.AvatarCacheSource.AvatarImage;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarCacheSource.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarCacheSource.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.scm.impl.avatars;
+
+import java.awt.image.BufferedImage;
+
+/**
+ *
+ * Interface for Avatar Cache Item Source
+ * 
+ * This defines a source for avatar to be ached and implementation to fetch it
+ */
+public interface AvatarCacheSource {
+    /**
+     * Holds Image and lastModified date
+     */
+    public static class AvatarImage {
+        /**
+         * Avatar Image
+         */
+        public final BufferedImage image;
+        /**
+         * Last Modified Timestamp
+         */
+        public final long lastModified;
+
+        /**
+         * Singleton for empty image
+         */
+        public static final AvatarImage EMPTY = new AvatarImage(null, 0);
+
+        public AvatarImage(final BufferedImage image, final long lastModified) {
+            this.image = image;
+            this.lastModified = lastModified;
+        }
+    }
+
+    /**
+     *
+     * Fetch image from source
+     *
+     * @return image as AvatarImage object
+     */
+    public AvatarImage fetch();
+
+    /**
+     * Get unique hash key for this item to be used for caching 
+     */
+    public String hashKey();
+
+    /**
+     * Make sure we can fetch
+     *
+     * @return true if can fetch
+     */
+    public boolean canFetch();
+}

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarImage.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarImage.java
@@ -23,30 +23,28 @@
  */
 package jenkins.scm.impl.avatars;
 
+import java.awt.image.BufferedImage;
+
 /**
- *
- * Interface for Avatar Cache Item Source
- * 
- * This defines a source for avatar to be ached and implementation to fetch it
+ * Holds Image and lastModified date
  */
-public interface AvatarCacheSource {
+public class AvatarImage {
     /**
-     *
-     * Fetch image from source
-     *
-     * @return image as AvatarImage object
+     * Avatar Image
      */
-    public AvatarImage fetch();
+    public final BufferedImage image;
+    /**
+     * Last Modified Timestamp
+     */
+    public final long lastModified;
 
     /**
-     * Get unique hash key for this item to be used for caching 
+     * Singleton for empty image
      */
-    public String hashKey();
+    public static final AvatarImage EMPTY = new AvatarImage(null, 0);
 
-    /**
-     * Make sure we can fetch
-     *
-     * @return true if can fetch
-     */
-    public boolean canFetch();
+    public AvatarImage(final BufferedImage image, final long lastModified) {
+        this.image = image;
+        this.lastModified = lastModified;
+    }
 }

--- a/src/main/java/jenkins/scm/impl/avatars/AvatarImageSource.java
+++ b/src/main/java/jenkins/scm/impl/avatars/AvatarImageSource.java
@@ -29,7 +29,7 @@ package jenkins.scm.impl.avatars;
  * 
  * This defines a source for avatar to be ached and implementation to fetch it
  */
-public interface AvatarCacheSource {
+public interface AvatarImageSource {
     /**
      *
      * Fetch image from source

--- a/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
+++ b/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
@@ -1,0 +1,137 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.scm.impl.avatars;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.imageio.ImageIO;
+import org.apache.commons.io.IOUtils;
+
+/**
+ *
+ * Basic URL based Cache Source - Fetches Image from HTTP/HTTPS URL without authentication
+ *
+ */
+public class UrlAvatarCacheSource implements AvatarCacheSource {
+    /**
+     * Our logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(UrlAvatarCacheSource.class.getName());
+
+    /**
+     * URL of the source image
+     */
+    private final String url;
+
+    public UrlAvatarCacheSource(String url) {
+        this.url = url;
+    }
+
+    /**
+     * CHeck if we can fetch. Only HTTP/HTTPS urls are supported
+     */
+    @Override
+    public boolean canFetch() {
+        return (url != null && (url.startsWith("http://") || url.startsWith("https://")));
+    }
+
+    /**
+     * Fetch image and return along with lastModified
+     */
+    @Override
+    public AvatarImage fetch() {
+        LOGGER.log(Level.FINE, "Attempting to fetch remote avatar: {0}", url);
+        long start = System.nanoTime();
+        try {
+            if (!canFetch()) {
+                LOGGER.log(Level.FINE, "Unable to fetch remote avatar: {0}", url);
+                return AvatarImage.EMPTY;
+            }
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            try {
+                connection.setConnectTimeout(10000);
+                connection.setReadTimeout(30000);
+                if (connection.getResponseCode() >= 400) {
+                    LOGGER.log(Level.FINE, "Got invalid content response {1} for remote avatar image from {0}",
+                            new String[] { url, String.valueOf(connection.getResponseCode()) });
+                    return AvatarImage.EMPTY;
+                }
+                String contentType = connection.getContentType();
+                if (contentType == null || !contentType.startsWith("image/")) {
+                    LOGGER.log(Level.FINE, "Got invalid content type {1} for remote avatar image from {0}",
+                            new String[] { url, contentType });
+                    return AvatarImage.EMPTY;
+                }
+                int length = connection.getContentLength();
+                // buffered stream should be no more than 16k if we know the length
+                // if we don't know the length then 8k is what we will use
+                length = length > 0 ? Math.min(16384, length) : 8192;
+                InputStream is = null;
+                try {
+                    is = connection.getInputStream();
+                    BufferedInputStream bis = new BufferedInputStream(is, length);
+                    BufferedImage image = ImageIO.read(bis);
+                    if (image == null) {
+                        LOGGER.log(Level.FINE, "Got no remote avatar image from {0}", url);
+                        return AvatarImage.EMPTY;
+                    }
+                    return new AvatarImage(image, connection.getLastModified());
+                } catch (Exception e) {
+                    LOGGER.log(Level.INFO, "1:" + e.getMessage(), e);
+                } finally {
+                    IOUtils.closeQuietly(is);
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.INFO, "2:" + e.getMessage(), e);
+            } finally {
+                connection.disconnect();
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.INFO, e.getMessage(), e);
+            return AvatarImage.EMPTY;
+        } finally {
+            long end = System.nanoTime();
+            long duration = TimeUnit.NANOSECONDS.toMillis(end - start);
+            LOGGER.log(duration > 250 ? Level.INFO : Level.FINE, "Avatar lookup of {0} took {1}ms",
+                    new Object[] { url, duration });
+        }
+        return AvatarImage.EMPTY;
+    }
+
+    /**
+     * Generate hash key used for caching
+     */
+    @Override
+    public String hashKey() {
+        // TODO Auto-generated method stub
+        return this.url;
+    }
+}

--- a/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
+++ b/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
@@ -40,7 +40,7 @@ import org.apache.commons.io.IOUtils;
  * Basic URL based Cache Source - Fetches Image from HTTP/HTTPS URL without authentication
  *
  */
-public class UrlAvatarCacheSource implements AvatarCacheSource {
+public class UrlAvatarCacheSource implements AvatarImageSource {
     /**
      * Our logger.
      */

--- a/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
+++ b/src/main/java/jenkins/scm/impl/avatars/UrlAvatarCacheSource.java
@@ -105,12 +105,12 @@ public class UrlAvatarCacheSource implements AvatarCacheSource {
                     }
                     return new AvatarImage(image, connection.getLastModified());
                 } catch (Exception e) {
-                    LOGGER.log(Level.INFO, "1:" + e.getMessage(), e);
+                    LOGGER.log(Level.INFO, "Failed to read from stream:" + e.getMessage(), e);
                 } finally {
                     IOUtils.closeQuietly(is);
                 }
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "2:" + e.getMessage(), e);
+                LOGGER.log(Level.INFO, "Failed to connect to remote:" + e.getMessage(), e);
             } finally {
                 connection.disconnect();
             }


### PR DESCRIPTION
As per https://issues.jenkins-ci.org/browse/JENKINS-59797

While trying to fix a problem with a plugin relying on this one, I have identified that AvatarCache only works for simple http/https urls without authentication, which obviously does not work for many SCMs that require authentication. In order to make it more flexible, I have added ability for SCM implementations to provide their own image sources and methods for fetching them instead of relying on what is hardcoded into AvatarCache.

I have included one implementation which copies the existing functionality and wrapped old methods using just URL to using that, so that this should continue to work with all existing code.

