### PR TITLE
Make `SCMTrait` implement `ExtensionPoint`

### DIFF
--- a/src/main/java/jenkins/scm/api/trait/SCMTrait.java
+++ b/src/main/java/jenkins/scm/api/trait/SCMTrait.java
@@ -27,6 +27,7 @@ package jenkins.scm.api.trait;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -38,7 +39,7 @@ import jenkins.model.Jenkins;
  *
  * @param <T> the type of {@link SCMTrait} specialization.
  */
-public abstract class SCMTrait<T extends SCMTrait<T>> extends AbstractDescribableImpl<T> {
+public abstract class SCMTrait<T extends SCMTrait<T>> extends AbstractDescribableImpl<T> implements ExtensionPoint {
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
I was wondering if there was not already some plugin out there which implemented an equivalent to https://github.com/jenkinsci/branch-api-plugin/pull/244. Unfortunately https://www.jenkins.io/doc/developer/extensions/scm-api/ does not as of this writing list traits; had to resort to https://github.com/search?q=user%3Ajenkinsci+%22extends+SCMSourceTraitDescriptor%22&type=Code + https://github.com/search?q=user%3Ajenkinsci+%22extends+SCMNavigatorTraitDescriptor%22&type=Code which is awkward.
