### PR TITLE
JENKINS-68116 Make event thread pool size customize-able

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMEvent.java
+++ b/src/main/java/jenkins/scm/api/SCMEvent.java
@@ -46,6 +46,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.servlet.http.HttpServletRequest;
 import jenkins.security.ImpersonatingScheduledExecutorService;
+import jenkins.util.SystemProperties;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
@@ -107,6 +108,9 @@ public abstract class SCMEvent<P> {
      * @since 2.0.3
      */
     public static final String ORIGIN_UNKNOWN = "?";
+
+    private static final int EVENT_THREAD_POOL_SIZE = SystemProperties
+        .getInteger(SCMEvent.class.getName() + ".EVENT_THREAD_POOL_SIZE", 10);
     /**
      * The event type.
      */
@@ -213,7 +217,7 @@ public abstract class SCMEvent<P> {
     protected static synchronized ScheduledExecutorService executorService() {
         if (executorService == null) {
             threadPoolExecutor = new ScheduledThreadPoolExecutor(
-                10,
+                EVENT_THREAD_POOL_SIZE,
                 new NamingThreadFactory(
                     new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "SCMEvent")
             );


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-68116

Slow processing of events is causing delays of over an hour for our users to have their builds / pushes picked up

Currently increases thread pool size from 10 -> 30 and adds a system property to make it customise-able

Last changed in https://github.com/jenkinsci/scm-api-plugin/pull/61

I've ran this for four hours on a busy controller and never saw the queue grow above 4 or the thread pool get maxed out with running threads (highest I saw was ~27).

Running this in script console shows the status:
```
$ jenkins.scm.api.SCMEvent.executorService

Result: java.util.concurrent.ScheduledThreadPoolExecutor@23c09aa1[Running, pool size = 30, active threads = 20, queued tasks = 0, completed tasks = 4029]
```

Related PR: https://github.com/jenkinsci/branch-api-plugin/pull/304