### PR TITLE
 JENKINS-68116 Export metrics for scm event queue performance

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMEvent.java
+++ b/src/main/java/jenkins/scm/api/SCMEvent.java
@@ -135,6 +135,7 @@ public abstract class SCMEvent<P> {
      * The scheduled executor thread pool. This is initialized lazily since it may be never needed.
      */
     private static ScheduledExecutorService executorService;
+    private static ScheduledThreadPoolExecutor threadPoolExecutor;
 
     /**
      * Constructor to use when the timestamp is available from the external SCM.
@@ -210,11 +211,39 @@ public abstract class SCMEvent<P> {
     @NonNull
     protected static synchronized ScheduledExecutorService executorService() {
         if (executorService == null) {
-            // corePoolSize is set to 10, but will only be created if needed.
-            // ScheduledThreadPoolExecutor "acts as a fixed-sized pool using corePoolSize threads"
-            executorService = new ImpersonatingScheduledExecutorService(new ScheduledThreadPoolExecutor(10, new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "SCMEvent")), ACL.SYSTEM);
+            threadPoolExecutor = new ScheduledThreadPoolExecutor(
+                10,
+                new NamingThreadFactory(
+                    new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "SCMEvent")
+            );
+            executorService = new ImpersonatingScheduledExecutorService(
+                threadPoolExecutor,
+                ACL.SYSTEM2);
         }
+
         return executorService;
+    }
+
+    public static EventQueueMetrics getEventProcessingMetrics() {
+        return new EventQueueMetrics();
+    }
+
+    public static class EventQueueMetrics {
+        public int getPoolSize() {
+            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getPoolSize();
+        }
+
+        public int getActiveThreads() {
+            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getActiveCount();
+        }
+
+        public int getQueuedTasks() {
+            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getQueue().size();
+        }
+
+        public long getCompletedTasks() {
+            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getCompletedTaskCount();
+        }
     }
 
 

--- a/src/main/java/jenkins/scm/api/SCMEvent.java
+++ b/src/main/java/jenkins/scm/api/SCMEvent.java
@@ -39,6 +39,7 @@ import hudson.util.NamingThreadFactory;
 import java.util.Date;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -225,24 +226,31 @@ public abstract class SCMEvent<P> {
     }
 
     public static EventQueueMetrics getEventProcessingMetrics() {
-        return new EventQueueMetrics();
+        return new EventQueueMetrics(threadPoolExecutor);
     }
 
     public static class EventQueueMetrics {
+
+        private final ThreadPoolExecutor executor;
+
+        public EventQueueMetrics(ThreadPoolExecutor executor) {
+            this.executor = executor;
+        }
+
         public int getPoolSize() {
-            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getPoolSize();
+            return executor == null ? 0 : executor.getPoolSize();
         }
 
         public int getActiveThreads() {
-            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getActiveCount();
+            return executor == null ? 0 : executor.getActiveCount();
         }
 
         public int getQueuedTasks() {
-            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getQueue().size();
+            return executor == null ? 0 : executor.getQueue().size();
         }
 
         public long getCompletedTasks() {
-            return threadPoolExecutor == null ? 0 : threadPoolExecutor.getCompletedTaskCount();
+            return executor == null ? 0 : executor.getCompletedTaskCount();
         }
     }
 


### PR DESCRIPTION
I would like to be able to monitor our SCM event queue and be able to measure the effect that tuning I do has on it.

see https://issues.jenkins.io/browse/JENKINS-68116

Implemented in the open telemetry plugin https://github.com/jenkinsci/opentelemetry-plugin/pull/388

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/21194782/161569702-64e3cc62-b5e7-41ee-83b7-f7bad6c36575.png">
