### PR TITLE
Null safety is improved in SCMFileSystem

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -30,6 +30,7 @@ import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -436,7 +437,7 @@ public abstract class SCMFileSystem implements Closeable {
             if (Util.isOverridden(SCMFileSystem.Builder.class, getClass(), "supportsDescriptor", SCMDescriptor.class)) {
                 return supportsDescriptor(descriptor);
             } else {
-                return descriptor.clazz.isAssignableFrom((getClass().getEnclosingClass())) ||
+                return isEnclosedByDescribable(descriptor) ||
                         getClass().getPackage().equals(descriptor.clazz.getPackage()) ||
                         getClass().getPackage().getName().startsWith(descriptor.clazz.getPackage().getName());
             }
@@ -466,7 +467,7 @@ public abstract class SCMFileSystem implements Closeable {
             if (Util.isOverridden(SCMFileSystem.Builder.class, getClass(), "supportsDescriptor", SCMSourceDescriptor.class)) {
                 return supportsDescriptor(descriptor);
             } else {
-                return descriptor.clazz.isAssignableFrom((getClass().getEnclosingClass())) ||
+                return isEnclosedByDescribable(descriptor) ||
                         getClass().getPackage().equals(descriptor.clazz.getPackage()) ||
                         getClass().getPackage().getName().startsWith(descriptor.clazz.getPackage().getName());
             }
@@ -525,6 +526,11 @@ public abstract class SCMFileSystem implements Closeable {
                 throw new IOException("Cannot instantiate a SCMFileSystem from an SCM without an owner");
             }
             return build(owner, source.build(head, rev), rev);
+        }
+
+        private boolean isEnclosedByDescribable(Descriptor<?> descriptor) {
+            Class<?> enclosingClass = getClass().getEnclosingClass();
+            return enclosingClass != null && descriptor.clazz.isAssignableFrom(enclosingClass);
         }
     }
 }


### PR DESCRIPTION
SCMFileSystem.Builder heuristics could cause NPE because results of the nullable `Class#getEnclosingClass()` method were directly passed to `Class#isAssignableFrom(Class)` method which does not accept `null`.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
