### PR TITLE
[JENKINS-69893] Remove border around section titles

### DIFF
--- a/src/main/resources/jenkins/scm/api/form/traits/traits.css
+++ b/src/main/resources/jenkins/scm/api/form/traits/traits.css
@@ -3,6 +3,7 @@ DIV.repeated-chunk.trait-section {
     text-align: center;
     margin: 0;
     padding: 0.1em;
+    border: 0 !important;
 }
 
 DIV.repeated-chunk.trait-section.trait-section-empty {


### PR DESCRIPTION
See [JENKINS-69893](https://issues.jenkins.io/browse/JENKINS-69893).

Tested only with browser's ad-hoc CSS editing.

Before: See JENKINS-69893.
After:
<img width="1320" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/206820453-d6135e88-67ad-41e6-92ff-672cae0904e0.png">