### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/jenkins/scm/api/form/traits/traits.js
+++ b/src/main/resources/jenkins/scm/api/form/traits/traits.js
@@ -1,36 +1,34 @@
 (function () {
     var traitSectionRule = function (e) {
-        e = $(e);
-        var p = $(e.previousSibling);
-        var n = $(e.nextSibling);
-        var empty = (!n || n.hasClassName("trait-section") || n.hasClassName("repeatable-insertion-point"));
+        var p = e.previousSibling;
+        var n = e.nextSibling;
+        var empty = (!n || n.classList.contains("trait-section") || n.classList.contains("repeatable-insertion-point"));
         // find any previous entries
-        while (p && p.hasClassName("trait-section")) {
-            p = $(p.previousSibling);
+        while (p && p.classList.contains("trait-section")) {
+            p = p.previousSibling;
         }
         if (!empty) {
             // skip our entries
-            while (n && !n.hasClassName("trait-section") && !n.hasClassName("repeatable-insertion-point")) {
-                n = $(n.nextSibling);
+            while (n && !n.classList.contains("trait-section") && !n.classList.contains("repeatable-insertion-point")) {
+                n = n.nextSibling;
             }
         }
         // find next section entries
-        while (n && n.hasClassName("trait-section") && !n.hasClassName("repeatable-insertion-point")) {
-            n = $(n.nextSibling);
+        while (n && n.classList.contains("trait-section") && !n.classList.contains("repeatable-insertion-point")) {
+            n = n.nextSibling;
         }
-        if ((!p && n.hasClassName("repeatable-insertion-point")) || empty) {
-            e.addClassName("trait-section-empty");
+        if ((!p && n.classList.contains("repeatable-insertion-point")) || empty) {
+            e.classList.add("trait-section-empty");
         } else {
-            e.removeClassName("trait-section-empty");
+            e.classList.remove("trait-section-empty");
         }
     };
     Behaviour.specify("DIV.trait-container", 'traits', -50, function (e) {
-        e = $(e);
         if (isInsideRemovable(e)) {
             return;
         }
         layoutUpdateCallback.add(function () {
-            findElementsBySelector(e, ".trait-section").each(traitSectionRule);
+            e.querySelectorAll(".trait-section").forEach(traitSectionRule);
         })
     });
     Behaviour.specify(".repeatable-delete", 'traits', 500, function (e) {
@@ -40,7 +38,7 @@
             if (btn) {
                 btn.on("click", function () {
                     window.setTimeout(function () {
-                        findElementsBySelector(c, ".trait-section").each(traitSectionRule);
+                        c.querySelectorAll(".trait-section").forEach(traitSectionRule);
                     }, 250);
                 });
             }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I stepped through the changed lines in a debugger and verified they were executed in my browser without any stack traces.