### PR TITLE
Require Jenkins 2.426.1 instead of 2.426

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>2555.v3190a_8a_c60c6</version>
+        <version>2612.v3d6a_2128c0ef</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426</jenkins.version>
+    <jenkins.version>2.426.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>


### PR DESCRIPTION
## Require Jenkins 2.426.1 instead of 2.426

- Bump io.jenkins.tools.bom:bom-2.426.x
- Require Jenkins 2.426.1 instead of 2.426

### Testing done

Rely on ci.jenkins.io to run the tests.

Includes pull request

* #232

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
