### PR TITLE
Add dependency on ASM API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>asm-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>


### PR DESCRIPTION
`SCMHeadMixinEqualityGenerator` depends on ASM, currently from Jenkins core. We'd eventually like to remove ASM from core in favor of the ASM API library plugin, but before we can do that, plugins need to start linking against the ASM API plugin. This PR prepares SCM API by linking against ASM API. As long as core continues to bundle ASM, core's copy will take precedence and this PR will have no effect in production besides forcing users to install the ASM API plugin. But once ASM is removed from core, then the ASM API plugin's copy will become the primary copy of ASM.

### Testing done

`mvn clean verify -Dtest=InjectedTest`