### PR TITLE
[JENKINS-72958] expose PrimaryInstanceMetadataAction to API

### DIFF
--- a/src/main/java/jenkins/scm/api/metadata/PrimaryInstanceMetadataAction.java
+++ b/src/main/java/jenkins/scm/api/metadata/PrimaryInstanceMetadataAction.java
@@ -33,6 +33,7 @@ import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceEvent;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Identifies a {@link SCMHead} / {@link SCMSource} as being a primary instance. Some examples of how this metadata is
@@ -70,6 +71,7 @@ import jenkins.scm.api.SCMSourceEvent;
  *
  * @since 2.0.1
  */
+@ExportedBean
 public class PrimaryInstanceMetadataAction extends InvisibleAction implements Serializable {
     /**
      * Ensure consistent serialization.


### PR DESCRIPTION
Enables JENKINS-72958. By exposing this bean the API now contains information indicating if a branch is a "default" branch.

### Testing done
See https://github.com/paychex/branch-api-plugin/tree/feature/JENKINS-72958

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
