### PR TITLE
remove dead yui code

### DIFF
--- a/src/main/resources/jenkins/scm/api/form/traits/traits.js
+++ b/src/main/resources/jenkins/scm/api/form/traits/traits.js
@@ -31,17 +31,4 @@
             e.querySelectorAll(".trait-section").forEach(traitSectionRule);
         })
     });
-    Behaviour.specify(".repeatable-delete", 'traits', 500, function (e) {
-        var c = e.closest(".trait-container");
-        if (c) {
-            var btn = YAHOO.widget.Button.getButton(e.id);
-            if (btn) {
-                btn.on("click", function () {
-                    window.setTimeout(function () {
-                        c.querySelectorAll(".trait-section").forEach(traitSectionRule);
-                    }, 250);
-                });
-            }
-        }
-    });
 })();


### PR DESCRIPTION
since longer time the repeatable delete is no longer a button created by yui but directly rendered by Jenkins core as button element  So the call to YAHOO.widget.Button.getButton(e.id) will always return undefined. The `layoutUpdateCallback` will make sure that when the delete button is clicked the `traitSectionRule` is called.

<!-- Please describe your pull request here. -->

### Testing done
Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
