### PR TITLE
Fix help display behaviors in the trait list UI

### DIFF
--- a/src/main/resources/jenkins/scm/api/form/traits.jelly
+++ b/src/main/resources/jenkins/scm/api/form/traits.jelly
@@ -105,18 +105,18 @@ THE SOFTWARE.
     <d:tag name="body">
       <local:blockWrapper>
         <j:set var="help" value="${descriptor.helpFile}"/>
+        <div class="help-sibling" style="width:100%">
           <local:row>
             <local:td>
-              <div>
-                <b>${descriptor.displayName}</b>
-              </div>
+              <b>${descriptor.displayName}</b>
+              <f:helpLink url="${help}"/>
             </local:td>
-            <f:helpLink url="${help}"/>
           </local:row>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
           <j:if test="${help!=null}">
             <f:helpArea/>
           </j:if>
+        </div>
 
         <d:invokeBody/>
 

--- a/src/main/resources/jenkins/scm/api/form/traits.jelly
+++ b/src/main/resources/jenkins/scm/api/form/traits.jelly
@@ -63,12 +63,10 @@ THE SOFTWARE.
     <d:tag name="body">
       <div>
         <j:set var="help" value="${descriptor.helpFile}"/>
-        <div class="help-sibling" style="width:100%">
+        <div class="help-sibling">
           <local:row>
-            <local:td>
-              <b>${descriptor.displayName}</b>
-              <f:helpLink url="${help}"/>
-            </local:td>
+            <b>${descriptor.displayName}</b>
+            <f:helpLink url="${help}"/>
           </local:row>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
           <j:if test="${help!=null}">

--- a/src/main/resources/jenkins/scm/api/form/traits.jelly
+++ b/src/main/resources/jenkins/scm/api/form/traits.jelly
@@ -65,7 +65,7 @@ THE SOFTWARE.
         <j:set var="help" value="${descriptor.helpFile}"/>
         <div class="help-sibling">
           <local:row>
-            <b>${descriptor.displayName}</b>
+            ${descriptor.displayName}
             <f:helpLink url="${help}"/>
           </local:row>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->


### PR DESCRIPTION
Wrap helpLink and helpArea in a `.help-sibling` container to ensure help content appears under the correct entry, rather than always in the first block. Also moved the helpLink inline with displayName inside the same <td> to improve layout.

- Fixes confusing UX in repeatable entries
- Matches Jenkins' help JavaScript behavior (finds closest `.help-sibling`)

Before:
![ezgif-8b255e49809e91](https://github.com/user-attachments/assets/aeb98c1b-dd15-4d12-97a7-2d5f62440213)

After:
![ezgif-8b01f6aaa1c984](https://github.com/user-attachments/assets/bbec43d3-9dcd-4e86-b529-ae59645789b0)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
